### PR TITLE
Add message key to secor.message.Message

### DIFF
--- a/src/main/java/com/pinterest/secor/message/ParsedMessage.java
+++ b/src/main/java/com/pinterest/secor/message/ParsedMessage.java
@@ -34,9 +34,9 @@ public class ParsedMessage extends Message {
                Arrays.toString(mPartitions) + '}';
     }
 
-    public ParsedMessage(String topic, int kafkaPartition, long offset, byte[] key,
-                         byte[] payload, String[] mPartitions) {
-        super(topic, kafkaPartition, offset, key, payload);
+    public ParsedMessage(String topic, int kafkaPartition, long offset, byte[] payload,
+                         String[] mPartitions) {
+        super(topic, kafkaPartition, offset, payload);
         this.mPartitions = mPartitions;
     }
 

--- a/src/main/java/com/pinterest/secor/parser/MessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/MessageParser.java
@@ -39,8 +39,7 @@ public abstract class MessageParser {
     public ParsedMessage parse(Message message) throws Exception {
         String[] partitions = extractPartitions(message);
         return new ParsedMessage(message.getTopic(), message.getKafkaPartition(),
-                                 message.getOffset(), message.getKey(),
-                                 message.getPayload(), partitions);
+                                 message.getOffset(), message.getPayload(), partitions);
     }
 
     public abstract String[] extractPartitions(Message payload) throws Exception;

--- a/src/test/java/com/pinterest/secor/common/LogFilePathTest.java
+++ b/src/test/java/com/pinterest/secor/common/LogFilePathTest.java
@@ -51,9 +51,7 @@ public class LogFilePathTest extends TestCase {
 
     public void testConstructFromMessage() throws Exception {
         ParsedMessage message = new ParsedMessage(TOPIC, KAFKA_PARTITION, 1000,
-                                                  "some_key".getBytes(),
-                                                  "some_payload".getBytes(),
-                                                  PARTITIONS);
+                                                  "some_payload".getBytes(), PARTITIONS);
         LogFilePath logFilePath = new LogFilePath(PREFIX, GENERATION, LAST_COMMITTED_OFFSET,
                                                   message);
         assertEquals(PATH, logFilePath.getLogFilePath());


### PR DESCRIPTION
We have a use case where we'd like to preserve the messages in Kafka logs with the same offset values.  To do this, we'd like to archive not only the message payload, but also the message header data (what the kafka `Message` class seem to term the "key.")

Looking at the internals of secor, the "key" was lost when the kafka `Message` was converted to a secor `Message`.  This diff adds the key to the secor `Message` class.

Few notes on this diff:
1. I didn't see any existing tests for this area of the code, so I didn't add any tests.  If you would like me to do so, please let me know and I can try.
2. I'm not 100% happy with having to copy the bytes in the `messageAndOffset.message().key()` `ByteBuffer` to the `key` `byte[]`, but I just copied the implementation for the `payload` variable which uses the same technique. Let me know if this is going to be a problem.
3. We could, hypothetically, archive to a kafka log file with a "key" by calculating our own crc32 checksum and meaningless magic and attributes bytes but we'd like to try to keep the format as consistent as the _actual_ log file as possible, potentially restoring our archived logs to actual broker machines.

Let me know if you have any questions.  Thanks!
