### PR TITLE
Expose Kafka socket parameters, max message size.

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -36,7 +36,13 @@ zookeeper.sync.time.ms=200
 kafka.consumer.timeout.ms=10000
 
 # Max number of retries during rebalance.
-kafka.rebalance.max.retries=20
+kafka.rebalance.max.retries=
+
+# Kafka consumer receive buffer size (socket.receive.buffer.bytes)
+kafka.socket.receive.buffer.bytes=
+
+# Kafka fetch max size (fetch.message.max.bytes)
+kafka.fetch.message.max.bytes=
 
 # Port of the broker serving topic partition metadata.
 kafka.seed.broker.port=9092

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -69,8 +69,16 @@ public class SecorConfig {
         return getInt("kafka.consumer.timeout.ms");
     }
 
-    public int getRebalanceMaxRetries() {
-        return getInt("kafka.rebalance.max.retries");
+    public String getRebalanceMaxRetries() {
+        return getString("kafka.rebalance.max.retries");
+    }
+
+    public String getFetchMessageMaxBytes() {
+        return getString("kafka.fetch.message.max.bytes");
+    }
+
+    public String getSocketReceieveBufferBytes() {
+        return getString("kafka.socket.receive.buffer.bytes");
     }
 
     public int getGeneration() {

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -109,8 +109,16 @@ public class MessageReader {
         // topics whose number of partitions has changed.
         props.put("auto.offset.reset", "smallest");
         props.put("consumer.timeout.ms", Integer.toString(mConfig.getConsumerTimeoutMs()));
-        props.put("rebalance.max.retries", Integer.toString(mConfig.getRebalanceMaxRetries()));
         props.put("consumer.id", IdUtil.getConsumerId());
+        if (mConfig.getRebalanceMaxRetries() != null && !mConfig.getRebalanceMaxRetries().isEmpty()) {
+            props.put("rebalance.max.retries", mConfig.getRebalanceMaxRetries());
+        }
+        if (mConfig.getSocketReceieveBufferBytes() != null && !mConfig.getSocketReceieveBufferBytes().isEmpty()) {
+            props.put("socket.receive.buffer.bytes", mConfig.getSocketReceieveBufferBytes());
+        }
+        if (mConfig.getFetchMessageMaxBytes() != null && !mConfig.getFetchMessageMaxBytes().isEmpty()) {
+            props.put("fetch.message.max.bytes", mConfig.getFetchMessageMaxBytes());
+        }
 
         return new ConsumerConfig(props);
     }


### PR DESCRIPTION
@pgarbacki

One more PR for you.  It's important to be able to set these values for the client, especially the max message size (because if the server uses a size larger than the default, the consumer will fail).
