### PR TITLE
[secor] json-smart version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>1.2</version>
+            <version>2.0-RC3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
The current version of `json-smart` throws an exception when your JSON has duplicate keys. This causes some of our data to be improperly bucketed into a catchall `1970-01-01` bucket. Version `2.0-RC3` of `json-smart` does throw an exception when when parsing JSON with duplicate keys, allowing data to be properly bucketed.

Simply bumping the version appears to work as the interface into parsing used in secor (`JSONValue.parse`) is still the same.
