### PR TITLE
Offsets storage path fixed in zk

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -58,7 +58,7 @@ public class SecorConfig {
         return mSecorConfig.get();
     }
 
-    private SecorConfig(PropertiesConfiguration properties) {
+    protected SecorConfig(PropertiesConfiguration properties) {
         mProperties = properties;
     }
 

--- a/src/test/java/com/pinterest/secor/common/ZookeeperConnectorTest.java
+++ b/src/test/java/com/pinterest/secor/common/ZookeeperConnectorTest.java
@@ -1,0 +1,30 @@
+package com.pinterest.secor.common;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ZookeeperConnectorTest {
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @Test
+    public void testGetCommittedOffsetGroupPath() throws Exception {
+        verify("/", "/consumers/secor_cg/offsets");
+        verify("/chroot", "/chroot/consumers/secor_cg/offsets");
+        verify("/chroot/", "/chroot/consumers/secor_cg/offsets");
+    }
+
+    protected void verify(String zookeeperPath, String expectedOffsetPath) {
+        ZookeeperConnector zookeeperConnector = new ZookeeperConnector();
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty("kafka.zookeeper.path", zookeeperPath);
+        properties.setProperty("secor.kafka.group", "secor_cg");
+        SecorConfig secorConfig = new SecorConfig(properties);
+        zookeeperConnector.setConfig(secorConfig);
+        Assert.assertEquals(expectedOffsetPath, zookeeperConnector.getCommittedOffsetGroupPath());
+    }
+}


### PR DESCRIPTION
Keeping offsets inside `kafka.zookeeper.path`
