### PR TITLE
Modified consumer to adjust seen offset for all messages.

### DIFF
--- a/src/main/java/com/pinterest/secor/consumer/Consumer.java
+++ b/src/main/java/com/pinterest/secor/consumer/Consumer.java
@@ -93,6 +93,12 @@ public class Consumer extends Thread {
                 LOG.trace("Consumer timed out", e);
             }
             if (rawMessage != null) {
+                // Before parsing, update the offset and remove any redundant data
+                try {
+                    mMessageWriter.adjustOffset(rawMessage);
+                } catch (IOException e) {
+                    throw new RuntimeException("Failed to adjust offset.", e);
+                }
                 ParsedMessage parsedMessage = null;
                 try {
                     parsedMessage = mMessageParser.parse(rawMessage);

--- a/src/main/java/com/pinterest/secor/writer/MessageWriter.java
+++ b/src/main/java/com/pinterest/secor/writer/MessageWriter.java
@@ -18,6 +18,7 @@ package com.pinterest.secor.writer;
 
 import com.pinterest.secor.common.*;
 import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
 import com.pinterest.secor.message.ParsedMessage;
 
 import java.io.IOException;
@@ -61,7 +62,7 @@ public class MessageWriter {
         mLocalPrefix = mConfig.getLocalPath() + '/' + IdUtil.getLocalMessageDir();
     }
 
-    private void adjustOffset(ParsedMessage message) throws IOException {
+    public void adjustOffset(Message message) throws IOException {
         TopicPartition topicPartition = new TopicPartition(message.getTopic(),
                                                            message.getKafkaPartition());
         long lastSeenOffset = mOffsetTracker.getLastSeenOffset(topicPartition);
@@ -77,7 +78,6 @@ public class MessageWriter {
     }
 
     public void write(ParsedMessage message) throws IOException {
-        adjustOffset(message);
         TopicPartition topicPartition = new TopicPartition(message.getTopic(),
                                                            message.getKafkaPartition());
         long offset = mOffsetTracker.getAdjustedCommittedOffsetCount(topicPartition);


### PR DESCRIPTION
Modified consumer to adjust seen offset for all messages, regardless of whether a message is parseable.

This fixes an issue with good data being thrown away when an un-parseable message is read from Kafka.
