### PR TITLE
Date based partitioning

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -97,6 +97,13 @@ message.timestamp.name=timestamp
 # Should be used when there is no timestamp in a Long format. Also ignore time zones.
 message.timestamp.input.pattern=
 
+# Pattern to use when construct the partition base on the date.
+# if empty use the default (dt=yyyy-MM-dd)
+# Example:
+#   if pattern is: 'y='yyyy/'m='MM/'d='dd
+#   then message with date 2014-10-29 will be written to s3 path s3n://.../y=2014/m=10/d=29/...
+message.partition.timestamp.pattern=
+
 # To enable compression, set this to a valid compression codec, such as 'org.apache.hadoop.io.compress.GzipCodec'.
 secor.compression.codec=
 

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -195,6 +195,10 @@ public class SecorConfig {
         return getString("message.timestamp.input.pattern");
     }
 
+    public String getMessagePartitionTimestampPattern() {
+        return getString("message.partition.timestamp.pattern");
+    }
+
     public String getCompressionCodec() {
         return getString("secor.compression.codec");
     }

--- a/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
@@ -41,6 +41,7 @@ public class DateMessageParser extends MessageParser {
     private static final Logger LOG = LoggerFactory.getLogger(DateMessageParser.class);
     protected static final String defaultDate = "dt=1970-01-01";
     protected static final String defaultFormatter = "yyyy-MM-dd";
+    protected static final String defaultPrefix = "dt=";
 
     public DateMessageParser(SecorConfig config) {
         super(config);
@@ -53,17 +54,20 @@ public class DateMessageParser extends MessageParser {
 
         if (jsonObject != null) {
             Object fieldValue = jsonObject.get(mConfig.getMessageTimestampName());
-            Object inputPattern = mConfig.getMessageTimestampInputPattern();
-            if (fieldValue != null && inputPattern != null) {
+            String inputPattern = mConfig.getMessageTimestampInputPattern();
+            String partitionPattern = mConfig.getMessagePartitionTimestampPattern();
+
+            if (fieldValue != null && inputPattern != null && !inputPattern.isEmpty()) {
                 try {
-                    SimpleDateFormat inputFormatter = new SimpleDateFormat(inputPattern.toString());
-                    SimpleDateFormat outputFormatter = new SimpleDateFormat(defaultFormatter);
+                    SimpleDateFormat inputFormatter = new SimpleDateFormat(inputPattern);
+                    SimpleDateFormat outputFormatter = new SimpleDateFormat(partitionPattern != null && !partitionPattern.isEmpty() ? partitionPattern : defaultFormatter);
+                    String prefix = partitionPattern != null && !partitionPattern.isEmpty() ? "" : defaultPrefix;
                     Date dateFormat = inputFormatter.parse(fieldValue.toString());
-                    result[0] = "dt=" + outputFormatter.format(dateFormat);
+                    result[0] = prefix + outputFormatter.format(dateFormat);
                     return result;
                 } catch (Exception e) {
                     LOG.warn("Impossible to convert date = " + fieldValue.toString()
-                            + " for the input pattern = " + inputPattern.toString()
+                            + " for the input pattern = " + inputPattern
                             + ". Using date default=" + result[0]);
                 }
             }

--- a/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
@@ -27,6 +27,9 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.message.Message;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 @RunWith(PowerMockRunner.class)
 public class DateMessageParserTest extends TestCase {
 
@@ -34,8 +37,9 @@ public class DateMessageParserTest extends TestCase {
     private Message mFormat1;
     private Message mFormat2;
     private Message mFormat3;
+    private Message mFormat4;
+    private Message mFormat5;
     private Message mInvalidDate;
-    private OngoingStubbing<String> getTimestamp;
 
     @Override
     public void setUp() throws Exception {
@@ -54,35 +58,60 @@ public class DateMessageParserTest extends TestCase {
                 .getBytes("UTF-8");
         mFormat3 = new Message("test", 0, 0, format3);
 
+        byte format4[] = "{\"timestamp\":\"2014-10-27T18:32:28.173Z\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mFormat4 = new Message("test", 0, 0, format4);
+
+        byte format5[] = "{\"timestamp\":\"2014-10-27T17:02:26.1239675-04:00\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+                .getBytes("UTF-8");
+        mFormat5 = new Message("test", 0, 0, format5);
+
         byte invalidDate[] = "{\"timestamp\":\"11111111\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
                 .getBytes("UTF-8");
         mInvalidDate = new Message("test", 0, 0, invalidDate);
-        
-        getTimestamp = Mockito.when(mConfig.getMessageTimestampInputPattern());
+
+
     }
 
     @Test
     public void testExtractDateUsingInputPattern() throws Exception {
-        getTimestamp.thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getMessagePartitionTimestampPattern()).thenReturn(null);
         assertEquals("dt=2014-07-30", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
 
-        getTimestamp.thenReturn("yyyy/MM/d");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy/MM/d");
+        Mockito.when(mConfig.getMessagePartitionTimestampPattern()).thenReturn("");
         assertEquals("dt=2014-10-25", new DateMessageParser(mConfig).extractPartitions(mFormat2)[0]);
 
-        getTimestamp.thenReturn("yyyyy.MMMMM.dd GGG hh:mm aaa");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyyy.MMMMM.dd GGG hh:mm aaa");
         assertEquals("dt=2001-07-04", new DateMessageParser(mConfig).extractPartitions(mFormat3)[0]);
     }
 
     @Test
     public void testExtractDateWithWrongEntries() throws Exception {
         // invalid date
-        getTimestamp.thenReturn("yyyy-MM-dd HH:mm:ss"); // any pattern
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss"); // any pattern
         assertEquals(DateMessageParser.defaultDate, new DateMessageParser(
                 mConfig).extractPartitions(mInvalidDate)[0]);
 
         // invalid pattern
-        getTimestamp.thenReturn("yyy-MM-dd :s");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyy-MM-dd :s");
         assertEquals(DateMessageParser.defaultDate, new DateMessageParser(
                 mConfig).extractPartitions(mFormat1)[0]);
+    }
+
+    @Test
+    public void testExtractDatePartitionUsingInputAndOutputPattern() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getMessagePartitionTimestampPattern()).thenReturn("'y='yyyy/'m='MM/'d='dd/'h='HH");
+        assertEquals("y=2014/m=07/d=30/h=10", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH");
+        Mockito.when(mConfig.getMessagePartitionTimestampPattern()).thenReturn("'y='yyyy/'m='MM/'d='dd/'h='HH");
+        assertEquals("y=2014/m=10/d=27/h=18", new DateMessageParser(mConfig).extractPartitions(mFormat4)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH");
+        Mockito.when(mConfig.getMessagePartitionTimestampPattern()).thenReturn("'y='yyyy/'m='MM/'d='dd/'h='HH");
+        assertEquals("y=2014/m=10/d=27/h=17", new DateMessageParser(mConfig).extractPartitions(mFormat5)[0]);
     }
 }


### PR DESCRIPTION
Added functionality to the DateMessageParser to handle partitioning data into a date-based directory structure. For example, the user can specify
a partition pattern that writes files to the following folder structure:

s3n://.../y=2014/m=08/d=09/...

This change maintains backwards compatibility with the original
partitioning scheme with prefix.