### PR TITLE
Add (basic) Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk6
+  - openjdk7


### PR DESCRIPTION
Simple PR to add a very basic `.travis.yml` configuration file that runs the tests for a couple of various JDKs, as (at least) I think that testing is important and it doesn't hurt when automation is free, right?

As a side note, make sure to enable this repo through the Travis CI management interface.
