### PR TITLE
Different log message for new partition in OffsetTracker

### DIFF
--- a/src/main/java/com/pinterest/secor/common/OffsetTracker.java
+++ b/src/main/java/com/pinterest/secor/common/OffsetTracker.java
@@ -51,9 +51,14 @@ public class OffsetTracker {
         long lastSeenOffset = getLastSeenOffset(topicPartition);
         mLastSeenOffset.put(topicPartition, offset);
         if (lastSeenOffset + 1 != offset) {
-            LOG.warn("offset for topic " + topicPartition.getTopic() + " partition " +
-                     topicPartition.getPartition() + " changed from " + lastSeenOffset + " to " +
-                     offset);
+            if (lastSeenOffset >= 0) {
+                LOG.warn("offset for topic " + topicPartition.getTopic() + " partition " +
+                        topicPartition.getPartition() + " changed from " + lastSeenOffset + " to " +
+                        offset);
+            } else {
+                LOG.info("starting to consume topic " + topicPartition.getTopic() + " partition " +
+                        topicPartition.getPartition() + " from offset " + offset);
+            }
         }
         if (mFirstSeendOffset.get(topicPartition) == null) {
             mFirstSeendOffset.put(topicPartition, offset);


### PR DESCRIPTION
Currently when Secor starts consuming a “new” partition it logs a warning that the offset for a given partition changed from -2 to _something_, and I’d say that this particular scenario is expected and shouldn’t generate a warning, but rather an info message that consumption of a new partition has started.

For future reference, -2 means to start from the earliest available offset and -1 means to start from the latest available offset, if I remember correctly.
