### PR TITLE
MessagePack parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ One of the convenience features of Secor is the ability to group messages and sa
 
 - **JSON date parser**: parser that extracts timestamps from JSON messages and groups the output based on the date, similar to the Thrift parser above. To use this parser, start Secor with properties file [secor.prod.partition.properties](src/main/config/secor.prod.partition.properties) and set `secor.message.parser.class=com.pinterest.secor.parser.JsonMessageParser`. You may override the field used to extract the timestamp by setting the "message.timestamp.name" property.
 
+- **msgpack date parser**: parser that extracts timestamps from MessagePack messages and groups the output based on the date, similar to the Thrift and JSON parser. To use this parser, set `secor.message.parser.class=com.pinterest.secor.parser.MessagePackParser`. Like the Thrift parser, the timestamp may be expressed either in seconds or milliseconds, or nanoseconds since the epoch and respects the "message.timestamp.name" property.
+
+
 If none of the parsers available out-of-the-box is suitable for your use case, note that it is very easy to implement a custom parser. All you have to do is to extend [MessageParser](src/main/java/com/pinterest/secor/parser/MessageParser.java) and tell Secor to use your parser by setting ```secor.message.parser.class``` in the properties file.
 
 ## Tools

--- a/pom.xml
+++ b/pom.xml
@@ -151,6 +151,11 @@
             <version>1.5.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.msgpack</groupId>
+            <artifactId>msgpack</artifactId>
+            <version>0.6.11</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -90,7 +90,7 @@ tsdb.hostport=
 # Regex of topics that are not exported to TSDB.
 tsdb.blacklist.topics=
 
-# Name of field that contains timestamp for JSON or Thrift message parser. (1405970352123)
+# Name of field that contains timestamp for JSON, MessagePack, or Thrift message parser. (1405970352123)
 message.timestamp.name=timestamp
 
 # Name of field that contains a timestamp, as a date Format, for JSON. (2014-08-07, Jul 23 02:16:57 2005, etc...)

--- a/src/main/java/com/pinterest/secor/parser/MessagePackParser.java
+++ b/src/main/java/com/pinterest/secor/parser/MessagePackParser.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import org.msgpack.MessagePack;
+import org.msgpack.MessageTypeException;
+import org.msgpack.type.MapValue;
+import org.msgpack.type.RawValue;
+import org.msgpack.type.Value;
+import org.msgpack.type.ValueFactory;
+
+/**
+ * MessagePack timestamped message parser.
+ * Requires a second or ms timestamp.
+ * Does not support message.timestamp.input.pattern.
+ *
+ * @author Zack Dever (zack@rd.io)
+ */
+public class MessagePackParser extends TimestampedMessageParser {
+    private MessagePack mMessagePack = new MessagePack();
+    private RawValue mTimestampField;
+
+    public MessagePackParser(SecorConfig config) {
+        super(config);
+        String timestampName = mConfig.getMessageTimestampName();
+        mTimestampField = ValueFactory.createRawValue(timestampName);
+    }
+
+    @Override
+    public long extractTimestampMillis(Message message) throws Exception {
+        MapValue msgMap = mMessagePack.read(message.getPayload()).asMapValue();
+        Value timestampValue = msgMap.get(mTimestampField);
+
+        if (timestampValue.isIntegerValue()) {
+            return toMillis(timestampValue.asIntegerValue().getLong());
+        } else if (timestampValue.isFloatValue()) {
+            return toMillis(timestampValue.asFloatValue().longValue());
+        } else {
+            String timestampString = timestampValue.asRawValue().getString();
+            return toMillis(Long.parseLong(timestampString));
+        }
+    }
+}

--- a/src/test/java/com/pinterest/secor/parser/MessagePackParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/MessagePackParserTest.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.msgpack.MessagePack;
+import org.msgpack.MessageTypeException;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashMap;
+
+@RunWith(PowerMockRunner.class)
+public class MessagePackParserTest extends TestCase {
+
+    private MessagePackParser mMessagePackParser;
+    private MessagePack mMessagePack;
+    private Message mMessageWithSecondsTimestamp;
+    private Message mMessageWithMillisTimestamp;
+    private Message mMessageWithMillisFloatTimestamp;
+    private Message mMessageWithMillisStringTimestamp;
+
+    @Override
+    public void setUp() throws Exception {
+        SecorConfig mConfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("ts");
+        mMessagePackParser = new MessagePackParser(mConfig);
+
+        mMessagePack = new MessagePack();
+
+        HashMap<String, Object> mapWithSecondTimestamp = new HashMap<String, Object>();
+        mapWithSecondTimestamp.put("ts", 1405970352);
+        mMessageWithSecondsTimestamp = new Message("test", 0, 0,
+                mMessagePack.write(mapWithSecondTimestamp));
+
+        HashMap<String, Object> mapWithMillisTimestamp = new HashMap<String, Object>();
+        mapWithMillisTimestamp.put("ts", 1405970352123l);
+        mapWithMillisTimestamp.put("isActive", true);
+        mapWithMillisTimestamp.put("email", "alice@example.com");
+        mapWithMillisTimestamp.put("age", 27);
+        mMessageWithMillisTimestamp = new Message("test", 0, 0,
+                mMessagePack.write(mapWithMillisTimestamp));
+
+        HashMap<String, Object> mapWithMillisFloatTimestamp = new HashMap<String, Object>();
+        mapWithMillisFloatTimestamp.put("ts", 1405970352123.0);
+        mapWithMillisFloatTimestamp.put("isActive", false);
+        mapWithMillisFloatTimestamp.put("email", "bob@example.com");
+        mapWithMillisFloatTimestamp.put("age", 35);
+        mMessageWithMillisFloatTimestamp = new Message("test", 0, 0,
+                mMessagePack.write(mapWithMillisFloatTimestamp));
+
+        HashMap<String, Object> mapWithMillisStringTimestamp = new HashMap<String, Object>();
+        mapWithMillisStringTimestamp.put("ts", "1405970352123");
+        mapWithMillisStringTimestamp.put("isActive", null);
+        mapWithMillisStringTimestamp.put("email", "charlie@example.com");
+        mapWithMillisStringTimestamp.put("age", 67);
+        mMessageWithMillisStringTimestamp = new Message("test", 0, 0,
+                mMessagePack.write(mapWithMillisStringTimestamp));
+
+    }
+
+    @Test
+    public void testExtractTimestampMillis() throws Exception {
+        assertEquals(1405970352000l, mMessagePackParser.extractTimestampMillis(
+                mMessageWithSecondsTimestamp));
+        assertEquals(1405970352123l, mMessagePackParser.extractTimestampMillis(
+                mMessageWithMillisTimestamp));
+        assertEquals(1405970352123l, mMessagePackParser.extractTimestampMillis(
+                mMessageWithMillisFloatTimestamp));
+        assertEquals(1405970352123l, mMessagePackParser.extractTimestampMillis(
+                mMessageWithMillisStringTimestamp));
+    }
+
+    @Test(expected=NullPointerException.class)
+    public void testMissingTimestamp() throws Exception {
+        HashMap<String, Object> mapWithoutTimestamp = new HashMap<String, Object>();
+        mapWithoutTimestamp.put("email", "mary@example.com");
+        Message nMessageWithoutTimestamp = new Message("test", 0, 0,
+                mMessagePack.write(mapWithoutTimestamp));
+        mMessagePackParser.extractTimestampMillis(nMessageWithoutTimestamp);
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testUnsupportedTimestampFormat() throws Exception {
+        HashMap<String, Object> mapWitUnsupportedFormatTimestamp = new HashMap<String, Object>();
+        mapWitUnsupportedFormatTimestamp.put("ts", "2014-11-14T18:12:52.878Z");
+        Message nMessageWithUnsupportedFormatTimestamp = new Message("test", 0, 0,
+                mMessagePack.write(mapWitUnsupportedFormatTimestamp));
+        mMessagePackParser.extractTimestampMillis(nMessageWithUnsupportedFormatTimestamp);
+    }
+
+    @Test(expected=MessageTypeException.class)
+    public void testNullTimestamp() throws Exception {
+        HashMap<String, Object> mapWitNullTimestamp = new HashMap<String, Object>();
+        mapWitNullTimestamp.put("ts", null);
+        Message nMessageWithNullTimestamp = new Message("test", 0, 0,
+                mMessagePack.write(mapWitNullTimestamp));
+        mMessagePackParser.extractTimestampMillis(nMessageWithNullTimestamp);
+    }
+
+    @Test
+    public void testExtractPartitions() throws Exception {
+        String expectedPartition = "dt=2014-07-21";
+
+        String resultSeconds[] = mMessagePackParser.extractPartitions(mMessageWithSecondsTimestamp);
+        assertEquals(1, resultSeconds.length);
+        assertEquals(expectedPartition, resultSeconds[0]);
+
+        String resultMillis[] = mMessagePackParser.extractPartitions(mMessageWithMillisTimestamp);
+        assertEquals(1, resultMillis.length);
+        assertEquals(expectedPartition, resultMillis[0]);
+    }
+}


### PR DESCRIPTION
This adds a generic MessagePack parser with date partitioning, much like the JSON parser. Includes unit tests.

If there is interest in merging this I can definitely poke around the integration test to make sure this is fully tested end to end (I did test it manually), or if someone has any quick pointers it would be appreciated.

I haven't written Java in quite some time so I'm sure it'll need some fixing up.
