### PR TITLE
Some groundwork for providing alternative FileReaderWriter

### DIFF
--- a/src/main/java/com/pinterest/secor/common/FileRegistry.java
+++ b/src/main/java/com/pinterest/secor/common/FileRegistry.java
@@ -99,9 +99,9 @@ public class FileRegistry {
             if (!files.contains(path)) {
                 files.add(path);
             }
-            writer = ((FileReaderWriter) ReflectionUtil.createFileReaderWriter(
+            writer = ReflectionUtil.createFileReaderWriter(
                     mConfig.getFileReaderWriter(), path, codec,
-                    FileReaderWriter.Type.Writer));
+                    FileReaderWriter.Type.Writer);
             mWriters.put(path, writer);
             mCreationTimes.put(path, System.currentTimeMillis() / 1000L);
             LOG.debug("created writer for path " + path.getLogFilePath());

--- a/src/main/java/com/pinterest/secor/consumer/Consumer.java
+++ b/src/main/java/com/pinterest/secor/consumer/Consumer.java
@@ -67,8 +67,7 @@ public class Consumer extends Thread {
         mMessageReader = new MessageReader(mConfig, mOffsetTracker);
         FileRegistry fileRegistry = new FileRegistry(mConfig);
         mMessageWriter = new MessageWriter(mConfig, mOffsetTracker, fileRegistry);
-        mMessageParser = (MessageParser) ReflectionUtil.createMessageParser(
-                mConfig.getMessageParserClass(), mConfig);
+        mMessageParser = ReflectionUtil.createMessageParser(mConfig.getMessageParserClass(), mConfig);
         mUploader = new Uploader(mConfig, mOffsetTracker, fileRegistry);
         mUnparsableMessages = 0.;
     }

--- a/src/main/java/com/pinterest/secor/io/FileReaderWriter.java
+++ b/src/main/java/com/pinterest/secor/io/FileReaderWriter.java
@@ -16,58 +16,68 @@
  */
 package com.pinterest.secor.io;
 
+import com.pinterest.secor.common.LogFilePath;
+import org.apache.hadoop.io.compress.CompressionCodec;
+
 import java.io.IOException;
 
 
 /**
  * Generic file reader/writer interface for all secor files
- * 
+ * <p/>
  * All implementations should define the constructor with the signature:
  * FileReaderWriter(LogFilePath path, CompressionCodec codec, FileReaderWriter.Type type)
- *
+ * <p/>
  * example: public SequenceFileReaderWriter(LogFilePath path, CompressionCodec codec,
- *           FileReaderWriter.Type type)
+ * FileReaderWriter.Type type)
  *
  * @author Praveen Murugesan (praveen@uber.com)
- *
  */
-public interface FileReaderWriter {
-    
+public abstract class FileReaderWriter {
+
+    protected FileReaderWriter() {
+    }
+
     public enum Type {
-        Reader, 
-        Writer;
+        Reader,
+        Writer
+    }
+
+    public FileReaderWriter(LogFilePath path, CompressionCodec codec, FileReaderWriter.Type type)
+            throws Exception {
+
     }
 
     /**
      * Get the next key/value from the file
-     * 
+     *
      * @return
      * @throws IOException
      */
-    public KeyValue next() throws IOException;
+    public abstract KeyValue next() throws IOException;
 
     /**
      * Close the file
-     * 
+     *
      * @throws IOException
      */
-    public void close() throws IOException;
+    public abstract void close() throws IOException;
 
     /**
      * Get length of data written up to now to the underlying file
-     * 
+     *
      * @return
      * @throws IOException
      */
-    public long getLength() throws IOException;
+    public abstract long getLength() throws IOException;
 
     /**
      * Write the given key and value to the file
-     * 
+     *
      * @param key
      * @param value
      * @throws IOException
      */
-    public void write(KeyValue keyValue) throws IOException;
+    public abstract void write(KeyValue keyValue) throws IOException;
 
 }

--- a/src/main/java/com/pinterest/secor/io/impl/DelimitedTextFileReaderWriter.java
+++ b/src/main/java/com/pinterest/secor/io/impl/DelimitedTextFileReaderWriter.java
@@ -41,7 +41,7 @@ import com.pinterest.secor.util.FileUtil;
  * @author Praveen Murugesan (praveen@uber.com)
  *
  */
-public class DelimitedTextFileReaderWriter implements FileReaderWriter {
+public class DelimitedTextFileReaderWriter extends FileReaderWriter {
 
     // delimiter used between messages
     private static final byte DELIMITER = '\n';

--- a/src/main/java/com/pinterest/secor/io/impl/SequenceFileReaderWriter.java
+++ b/src/main/java/com/pinterest/secor/io/impl/SequenceFileReaderWriter.java
@@ -38,7 +38,7 @@ import com.pinterest.secor.util.FileUtil;
  * @author Praveen Murugesan (praveen@uber.com)
  *
  */
-public class SequenceFileReaderWriter implements FileReaderWriter {
+public class SequenceFileReaderWriter extends FileReaderWriter {
 
     private final SequenceFile.Writer mWriter;
     private final SequenceFile.Reader mReader;
@@ -47,7 +47,8 @@ public class SequenceFileReaderWriter implements FileReaderWriter {
 
     // constructor
     public SequenceFileReaderWriter(LogFilePath path, CompressionCodec codec,
-            FileReaderWriter.Type type) throws Exception {
+        FileReaderWriter.Type type) throws Exception {
+        super(path, codec, type);
         Configuration config = new Configuration();
         Path fsPath = new Path(path.getLogFilePath());
         FileSystem fs = FileUtil.getFileSystem(path.getLogFilePath());
@@ -72,7 +73,6 @@ public class SequenceFileReaderWriter implements FileReaderWriter {
         } else {
             throw new IllegalArgumentException("Undefined File Type: " + type);
         }
-
     }
 
     @Override

--- a/src/test/java/com/pinterest/secor/util/ReflectionUtilTest.java
+++ b/src/test/java/com/pinterest/secor/util/ReflectionUtilTest.java
@@ -1,0 +1,45 @@
+package com.pinterest.secor.util;
+
+import com.pinterest.secor.common.LogFilePath;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.io.FileReaderWriter;
+import com.pinterest.secor.parser.MessageParser;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.Test;
+
+public class ReflectionUtilTest {
+
+    private SecorConfig mSecorConfig;
+    private LogFilePath mLogFilePath;
+
+    public void setUp() throws Exception {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        mSecorConfig = new SecorConfig(properties);
+        mLogFilePath = new LogFilePath("/foo", "/foo/bar/baz/1_1_1");
+    }
+
+    @Test
+    public void testCreateMessageParser() throws Exception {
+        MessageParser messageParser = ReflectionUtil.createMessageParser("com.pinterest.secor.parser.OffsetMessageParser",
+                mSecorConfig);
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testMessageParserClassNotFound() throws Exception {
+        ReflectionUtil.createMessageParser("com.example.foo", mSecorConfig);
+    }
+    @Test(expected = ClassNotFoundException.class)
+    public void testFileReaderWriterClassNotFound() throws Exception {
+        ReflectionUtil.createFileReaderWriter("com.example.foo", mLogFilePath, null, FileReaderWriter.Type.Writer);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testMessageParserConstructorMissing() throws Exception {
+        ReflectionUtil.createMessageParser("org.apache.commons.configuration.PropertiesConfiguration", mSecorConfig);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void testFileReaderWriterConstructorMissing() throws Exception {
+        ReflectionUtil.createFileReaderWriter("org.apache.commons.configuration.PropertiesConfiguration",
+                mLogFilePath, null, FileReaderWriter.Type.Writer);
+    }
+}


### PR DESCRIPTION
First, thanks for Secor - I'm finding it useful and well engineered.

I'm in the process of writing an AvroMessageParser and AvroFileReaderWriter. I'll try and abstract what's general about these and provide in a later pull request.

Currently you have a configuration that allows the MessageParser and FileReaderWriter classes to be pluggable (with the emphasis on the MessageParser where SequenceFileReaderWriter is already somewhat generic). An Avro container file is another possibiltiy for the file output. Currently FileReaderWriter is an interface whereas MessageParser is an abstract class. This seem a little inconsistent and provides no way to enforce the contract that ReflectionUtil expects from implementations of FileReaderWriter, namely a ternary constructor. By using an abstract class at least we can more heavily hint that this is needed (although we can't stop someone from overriding with a constructor with a different signature). We could make the contract explicit by using a factory class and an `Build()` method but this would require implementing a factory class that seems an unnecessary layer. Based on this thinking this PR:
- Makes FileReaderWriter an abstract class with the desired constructor implemented.
- Changes ReflectionUtil to return the concrete MessageParser and FileReaderWriter objects rather than Object.
- Assumes a constructor matching that of the base abstract classes exists (since only that will work) in both cases, rather than searching by arity.
- Ensures that the provided classes are assignable to MessageParser and FileReaderWriter.
- Adds some ReflectionUtil tests.

I'm making this now since if you agree with the changes I'll base my Avro plugins on them.

Thanks!
