### PR TITLE
Updating script to report success/failure more clearly

### DIFF
--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -34,8 +34,6 @@
 
 # Author: Pawel Garbacki (pawel@pinterest.com)
 
-#set -e
-
 PARENT_DIR=/tmp/secor_dev
 LOGS_DIR=${PARENT_DIR}/logs
 S3_LOGS_DIR=s3://pinterest-dev/secor_dev


### PR DESCRIPTION
Updating script to report success/failure more clearly by modifying verify method to dump the log message and aborting on failure.  Most commands are run in background so set -e does not really help - commenting it  and handling exit code for verification explicitly.

Testing: ran the new script for good and failure scenarios.
