### PR TITLE
Generalizing number conversion

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/JsonMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/JsonMessageParser.java
@@ -31,23 +31,12 @@ public class JsonMessageParser extends TimestampedMessageParser {
     }
 
     @Override
-    public long extractTimestampMillis(final Message message) throws ClassCastException {
+    public long extractTimestampMillis(final Message message) {
         JSONObject jsonObject = (JSONObject) JSONValue.parse(message.getPayload());
         if (jsonObject != null) {
             Object fieldValue = jsonObject.get(mConfig.getMessageTimestampName());
             if (fieldValue != null) {
-                long timestamp = 0;
-                if (fieldValue instanceof Number) {
-                    timestamp = ((Number) fieldValue).longValue();
-                } else {
-                    // Sadly, I don't know of a better way to support all numeric types in Java
-                    try {
-                        timestamp = Long.valueOf(fieldValue.toString());
-                    } catch (NumberFormatException e) {
-                        timestamp = Double.valueOf(fieldValue.toString()).longValue();
-                    }
-                }
-                return toMillis(timestamp);
+                return toMillis(Double.valueOf(fieldValue.toString()).longValue());
             }
         }
         return 0;


### PR DESCRIPTION
This approach works for integer, float/double and scientific notation (e.g., 12E+9).
The throws declaration was removed from method extractTimestampMillis().