### PR TITLE
using length of BytesWritable to decide how much of the byte array to di...

### DIFF
--- a/src/main/java/com/pinterest/secor/tools/LogFilePrinter.java
+++ b/src/main/java/com/pinterest/secor/tools/LogFilePrinter.java
@@ -50,7 +50,9 @@ public class LogFilePrinter {
             if (mPrintOffsetsOnly) {
                 System.out.println(Long.toString(key.get()));
             } else {
-                System.out.println(Long.toString(key.get()) + ": " + new String(value.getBytes()));
+                byte[] nonPaddedBytes = new byte[value.getLength()];
+                System.arraycopy(value.getBytes(), 0, nonPaddedBytes, 0, value.getLength());
+                System.out.println(Long.toString(key.get()) + ": " + new String(nonPaddedBytes)); 
             }
         }
     }


### PR DESCRIPTION
This is a know hadoop issue.  It is discussed here This is the bug in Hadoop https://issues.apache.org/jira/browse/HADOOP-6298.

Now using this to get the bytes out.
System.arraycopy(value.getBytes(), 0, nonPaddedBytes, 0, value.getLength());

