### PR TITLE
Add support for additional Kafka fetch options

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -47,6 +47,12 @@ kafka.socket.receive.buffer.bytes=
 # Kafka fetch max size (fetch.message.max.bytes)
 kafka.fetch.message.max.bytes=
 
+# Kafka fetch min bytes (fetch.fetch.min.bytes)
+kafka.fetch.min.bytes=
+
+# Kafka fetch max wait ms (fetch.max.wait.ms)
+kafka.fetch.wait.max.ms=
+
 # Port of the broker serving topic partition metadata.
 kafka.seed.broker.port=9092
 

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -103,6 +103,14 @@ public class SecorConfig {
         return getString("kafka.socket.receive.buffer.bytes");
     }
 
+    public String getFetchMinBytes() {
+        return getString("kafka.fetch.min.bytes");
+    }
+
+    public String getFetchWaitMaxMs() {
+        return getString("kafka.fetch.wait.max.ms");
+    }
+
     public int getGeneration() {
         return getInt("secor.generation");
     }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -125,6 +125,12 @@ public class MessageReader {
         if (mConfig.getFetchMessageMaxBytes() != null && !mConfig.getFetchMessageMaxBytes().isEmpty()) {
             props.put("fetch.message.max.bytes", mConfig.getFetchMessageMaxBytes());
         }
+        if (mConfig.getFetchMinBytes() != null && !mConfig.getFetchMinBytes().isEmpty()) {
+            props.put("fetch.min.bytes", mConfig.getFetchMinBytes());
+        }
+        if (mConfig.getFetchWaitMaxMs() != null && !mConfig.getFetchWaitMaxMs().isEmpty()) {
+            props.put("fetch.wait.max.ms", mConfig.getFetchWaitMaxMs());
+        }
 
         return new ConsumerConfig(props);
     }


### PR DESCRIPTION
Quite useful options for keeping the number of requests to a minimum for topics that doesn't get `fetch.message.max.bytes` worth of data within the default `fetch.wait.max.ms`, which is 100ms.