### PR TITLE
(Fully) local integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,20 @@
 language: java
+addons:
+  hosts:
+    - test-bucket.localhost
+env:
+  - PATH=$PATH:$HOME/.s3cmd SECOR_LOCAL_S3=true S3CMD=1.0.1
 jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk6
   - openjdk7
+  - oraclejdk7
+  - oraclejdk8
+before_install:
+  - wget https://github.com/s3tools/s3cmd/archive/v$S3CMD.tar.gz -O /tmp/s3cmd.tar.gz
+  - tar -xzf /tmp/s3cmd.tar.gz -C $HOME
+  - mv $HOME/s3cmd-$S3CMD $HOME/.s3cmd
+  - cd $HOME/.s3cmd && python setup.py install --user && cd -
+  - gem install fakes3 -v 0.1.7
+script:
+  - make unit
+  - make integration
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+CONFIG=src/main/config
+TEST_HOME=/tmp/secor_test
+TEST_CONFIG=src/test/config
+JAR_FILE=target/secor-*-SNAPSHOT-bin.tar.gz
+MVN_OPTS=-DskipTests=true -Dmaven.javadoc.skip=true
+
+build:
+	@mvn package $(MVN_OPTS)
+
+unit:
+	@mvn test
+
+integration: build
+	@rm -rf $(TEST_HOME)
+	@mkdir -p $(TEST_HOME)
+	@tar -xzf $(JAR_FILE) -C $(TEST_HOME)
+	@cp $(TEST_CONFIG)/* $(TEST_HOME)
+	@[ ! -e $(CONFIG)/jets3t.properties ] && jar uf $(TEST_HOME)/secor-*.jar -C $(TEST_CONFIG) jets3t.properties
+	cd $(TEST_HOME) && ./scripts/run_tests.sh
+
+test: build unit integration
+

--- a/src/main/config/secor.test.backup.properties
+++ b/src/main/config/secor.test.backup.properties
@@ -1,0 +1,3 @@
+include=secor.test.properties
+include=secor.dev.backup.properties
+

--- a/src/main/config/secor.test.partition.properties
+++ b/src/main/config/secor.test.partition.properties
@@ -1,0 +1,3 @@
+include=secor.test.properties
+include=secor.dev.partition.properties
+

--- a/src/main/config/secor.test.properties
+++ b/src/main/config/secor.test.properties
@@ -1,0 +1,4 @@
+secor.s3.bucket=test-bucket
+aws.access.key=TESTKEY
+aws.secret.key=TESTKEY
+

--- a/src/main/scripts/run_common.sh
+++ b/src/main/scripts/run_common.sh
@@ -12,3 +12,7 @@ if [ -z "${JAVA_HOME}" ]; then
 else
     JAVA="${JAVA_HOME}/bin/java"
 fi
+
+DEFAULT_CLASSPATH="*:lib/*"
+CLASSPATH=${CLASSPATH:-$DEFAULT_CLASSPATH}
+

--- a/src/main/scripts/run_kafka_class.sh
+++ b/src/main/scripts/run_kafka_class.sh
@@ -24,22 +24,6 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
-base_dir=$(dirname $0)/..
-
-SCALA_VERSION=2.8.0
-
-# assume all dependencies have been packaged into one jar with sbt-assembly's task
-# "assembly-package-dependency"
-# for file in lib/*.jar; do
-#   CLASSPATH=$CLASSPATH:$file
-# done
-
-# for file in $base_dir/kafka*.jar; do
-#   CLASSPATH=$CLASSPATH:$file
-# done
-
-CLASSPATH=${CLASSPATH}:${base_dir}/lib/*
-
 # JMX settings
 KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false "
 

--- a/src/main/scripts/run_zookeeper_command.sh
+++ b/src/main/scripts/run_zookeeper_command.sh
@@ -25,4 +25,4 @@ fi
 CURR_DIR=`dirname $0`
 source ${CURR_DIR}/run_common.sh
 
-${JAVA} -ea -cp "secor-0.1-SNAPSHOT.jar:lib/*" org.apache.zookeeper.ZooKeeperMain -server $@
+${JAVA} -ea -cp "$CLASSPATH" org.apache.zookeeper.ZooKeeperMain -server $@

--- a/src/test/config/jets3t.properties
+++ b/src/test/config/jets3t.properties
@@ -1,0 +1,3 @@
+s3service.https-only=false
+s3service.s3-endpoint-http-port=5000
+s3service.s3-endpoint=localhost

--- a/src/test/config/test.s3cfg
+++ b/src/test/config/test.s3cfg
@@ -1,0 +1,12 @@
+[default]
+access_key = TESTACCESSKEY
+bucket_location = US
+default_mime_type = binary/octet-stream
+encoding = UTF-8
+get_continue = False
+guess_mime_type = True
+host_base = localhost:5000
+host_bucket = %(bucket)s.localhost:5000
+secret_key = TESTSECRETKEY
+use_https = False
+verbosity = WARNING


### PR DESCRIPTION
This introduces a way to run the integration tests in a purely local fashion, using `fakes3` (a Ruby gem) rather than an actual S3 bucket.

In order to accomplish this a few configuration options needs to be set (AWS keys and S3 bucket), and I’ve included “defaults” that will work on Travis (in separate config. files). One also needs to add an entry to `/etc/hosts` (or equivalent), that points `test-bucket.localhost` to `127.0.0.1`.

There's a rather naive function, `check_for_native_libs`, that checks whether `HADOOP_NATIVE_LIB_PATH` actually contains any `*.so` files, and if it doesn’t it’ll ignore the “compressed tests” for sequence files, as it's not possible to run them without the native libs, and it's pretty darn difficult to build them on Mac OS X, not even sure if it's supported at all.

Furthermore there’s a Makefile that simplifies running the integration tests, a simple `make integration` is all that’s needed. It’ll build, package and extract Secor to a directory in `/tmp` and then run the tests.

Perhaps there should be a section in the README dedicated to how the test setup works, and how to run the tests.

Let me know what you think of this. The main benefit I see from this is having each pull request automatically run the integration tests on Travis (given that it's enable that is), and for me it's nice to be able to run the integration tests locally without having to communicate with S3 or any other third-party service (though it's only S3 in this case).