### PR TITLE
Check upload policy every N messages / seconds

### DIFF
--- a/src/main/java/com/pinterest/secor/consumer/Consumer.java
+++ b/src/main/java/com/pinterest/secor/consumer/Consumer.java
@@ -83,6 +83,7 @@ public class Consumer extends Thread {
         }
         // check upload policy every N seconds or 10,000 messages/consumer timeouts
         long checkEveryNSeconds = Math.min(10 * 60, mConfig.getMaxFileAgeSeconds() / 2);
+        long checkMessagesPerSecond = mConfig.getMessagesPerSecond();
         long nMessages = 0;
         long lastChecked = System.currentTimeMillis();
         while (true) {
@@ -92,7 +93,7 @@ public class Consumer extends Thread {
             }
 
             long now = System.currentTimeMillis();
-            if (nMessages++ % 10000 == 0 ||
+            if (nMessages++ % checkMessagesPerSecond == 0 ||
                     (now - lastChecked) > checkEveryNSeconds * 1000) {
                 lastChecked = now;
                 checkUploadPolicy();


### PR DESCRIPTION
During low traffic hours, our Secor instances process around 4000 messages per second, which means that we're checking if there are any logs eligible for upload all of the time. If we had a low `secor.max.file.age.seconds` value that would've been fine, but right now it's 3600 seconds (i.e. one hour), and `secor.max.file.size.bytes` is 1 Gigabyte, so this is currently a huge performance hit.

While reusing `secor.messages.per.second` (which is used for rate limiting) is not the best solution, it's a tradeoff between creating yet another configuration option or reusing an old one (which might have unintended side-effects for other users). The default specified in `secor.common.properties` is 10 000, and the one hardcoded is 10 000, so for anyone using that configuration file there's no difference (though I don't think most users are).

Feedback and thoughts about this is greatly appreciated.