### PR TITLE
avoid message toString when debug not enabled

### DIFF
--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -150,7 +150,7 @@ public class MessageReader {
         updateAccessTime(topicPartition);
         // Skip already committed messages.
         long committedOffsetCount = mOffsetTracker.getTrueCommittedOffsetCount(topicPartition);
-        LOG.debug("read message" + message);
+        LOG.debug("read message {}", message);
         exportStats();
         if (message.getOffset() < committedOffsetCount) {
             LOG.debug("skipping message message " + message + " because its offset precedes " +

--- a/src/main/java/com/pinterest/secor/writer/MessageWriter.java
+++ b/src/main/java/com/pinterest/secor/writer/MessageWriter.java
@@ -84,7 +84,7 @@ public class MessageWriter {
         		mFileExtension);
         FileWriter writer = mFileRegistry.getOrCreateWriter(path, mCodec);
         writer.write(new KeyValue(message.getOffset(), message.getPayload()));
-        LOG.debug("appended message " + message + " to file " + path.getLogFilePath() +
-                  ".  File length " + writer.getLength());
+        LOG.debug("appended message {} to file {}.  File length {}",
+                  message, path.getLogFilePath(), writer.getLength());
     }
 }


### PR DESCRIPTION
message.toString is called twice even when debug logging is not enabled

Because message can be huge, I used this method to avoid unnecessary calls. 
http://www.slf4j.org/faq.html#logging_performance