### PR TITLE
performance fix for small messages

### DIFF
--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -54,6 +54,9 @@ public class MessageReader {
     private ConsumerConnector mConsumerConnector;
     private ConsumerIterator mIterator;
     private HashMap<TopicPartition, Long> mLastAccessTime;
+    private final int mTopicPartitionForgetSeconds;
+    private final int mCheckMessagesPerSecond;
+    private int mNMessages;
 
     public MessageReader(SecorConfig config, OffsetTracker offsetTracker) throws
             UnknownHostException {
@@ -69,6 +72,8 @@ public class MessageReader {
         mIterator = stream.iterator();
         mLastAccessTime = new HashMap<TopicPartition, Long>();
         StatsUtil.setLabel("secor.kafka.consumer.id", IdUtil.getConsumerId());
+        mTopicPartitionForgetSeconds = mConfig.getTopicPartitionForgetSeconds();
+        mCheckMessagesPerSecond = mConfig.getMessagesPerSecond() / mConfig.getConsumerThreads();
     }
 
     private void updateAccessTime(TopicPartition topicPartition) {
@@ -78,7 +83,7 @@ public class MessageReader {
         while (iterator.hasNext()) {
             Map.Entry pair = (Map.Entry) iterator.next();
             long lastAccessTime = (Long) pair.getValue();
-            if (now - lastAccessTime > mConfig.getTopicPartitionForgetSeconds()) {
+            if (now - lastAccessTime > mTopicPartitionForgetSeconds) {
                 iterator.remove();
             }
         }
@@ -141,7 +146,10 @@ public class MessageReader {
 
     public Message read() {
         assert hasNext();
-        RateLimitUtil.acquire();
+        mNMessages = (mNMessages + 1) % mCheckMessagesPerSecond;
+        if (mNMessages % mCheckMessagesPerSecond == 0) {
+            RateLimitUtil.acquire(mCheckMessagesPerSecond);
+        }
         MessageAndMetadata<byte[], byte[]> kafkaMessage = mIterator.next();
         Message message = new Message(kafkaMessage.topic(), kafkaMessage.partition(),
                                       kafkaMessage.offset(), kafkaMessage.message());
@@ -151,7 +159,9 @@ public class MessageReader {
         // Skip already committed messages.
         long committedOffsetCount = mOffsetTracker.getTrueCommittedOffsetCount(topicPartition);
         LOG.debug("read message {}", message);
-        exportStats();
+        if (mNMessages % mCheckMessagesPerSecond == 0) {
+            exportStats();
+        }
         if (message.getOffset() < committedOffsetCount) {
             LOG.debug("skipping message {} because its offset precedes committed offset count {}",
                     message, committedOffsetCount);

--- a/src/main/java/com/pinterest/secor/util/RateLimitUtil.java
+++ b/src/main/java/com/pinterest/secor/util/RateLimitUtil.java
@@ -35,7 +35,7 @@ public class RateLimitUtil {
         mRateLimiter = RateLimiter.create(config.getMessagesPerSecond());
     }
 
-    public static void acquire() {
-        mRateLimiter.acquire();
+    public static void acquire(int n) {
+        mRateLimiter.acquire(n);
     }
 }

--- a/src/main/java/com/pinterest/secor/writer/MessageWriter.java
+++ b/src/main/java/com/pinterest/secor/writer/MessageWriter.java
@@ -48,6 +48,7 @@ public class MessageWriter {
     private String mFileExtension;
     private CompressionCodec mCodec;
     private String mLocalPrefix;
+    private final int mGeneration;
 
     public MessageWriter(SecorConfig config, OffsetTracker offsetTracker,
                          FileRegistry fileRegistry) throws Exception {
@@ -61,6 +62,7 @@ public class MessageWriter {
             mFileExtension = "";
         }
         mLocalPrefix = mConfig.getLocalPath() + '/' + IdUtil.getLocalMessageDir();
+        mGeneration = mConfig.getGeneration();
     }
 
     public void adjustOffset(Message message) throws IOException {
@@ -83,11 +85,11 @@ public class MessageWriter {
         TopicPartition topicPartition = new TopicPartition(message.getTopic(),
                                                            message.getKafkaPartition());
         long offset = mOffsetTracker.getAdjustedCommittedOffsetCount(topicPartition);
-        LogFilePath path = new LogFilePath(mLocalPrefix, mConfig.getGeneration(), offset, message,
+        LogFilePath path = new LogFilePath(mLocalPrefix, mGeneration, offset, message,
         		mFileExtension);
         FileWriter writer = mFileRegistry.getOrCreateWriter(path, mCodec);
         writer.write(new KeyValue(message.getOffset(), message.getPayload()));
         LOG.debug("appended message {} to file {}.  File length {}",
-                  message, path.getLogFilePath(), writer.getLength());
+                  message, path, writer.getLength());
     }
 }


### PR DESCRIPTION
This specific property is reloaded on every message read which cause server performance limited around 20k/s. Cache this as a static value.