### PR TITLE
Support uploads using the AWS SDK TransferManager.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
             <version>2.6.1</version>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>1.10.2</version>
+        </dependency>
+        <dependency>
             <groupId>net.java.dev.jets3t</groupId>
             <artifactId>jets3t</artifactId>
             <version>0.7.1</version>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -28,6 +28,18 @@ aws.secret.key=
 # END MUST SET #
 ################
 
+# AWS region or endpoint. region should be a known region name (eg.
+# us-east-1). endpoint should be a known S3 endpoint url. If neither
+# are specified, then the default region (us-east-1) is used. If both
+# are specified then endpoint is used.
+#
+# Only apply if the the S3UploadManager is used - see
+# secor.upload.manager.class.
+#
+# http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+aws.region=
+aws.endpoint=
+
 # Zookeeper config.
 zookeeper.session.timeout.ms=3000
 zookeeper.sync.time.ms=200
@@ -149,3 +161,7 @@ secor.file.reader.writer.factory=com.pinterest.secor.io.impl.SequenceFileReaderW
 # This should be set large enough to accept the max message size configured in your kafka broker
 # Default is 0.1 MB
 secor.max.message.size.bytes=100000
+
+# Class that will manage uploads. Default is to use the hadoop
+# interface to S3.
+secor.upload.manager.class=com.pinterest.secor.uploader.HadoopS3UploadManager

--- a/src/main/java/com/pinterest/secor/common/LogFilePath.java
+++ b/src/main/java/com/pinterest/secor/common/LogFilePath.java
@@ -114,6 +114,10 @@ public class LogFilePath {
         mOffset = Long.parseLong(basenameElements[2]);
     }
 
+    public LogFilePath withPrefix(String prefix) {
+        return new LogFilePath(prefix, mTopic, mPartitions, mGeneration, mKafkaPartition, mOffset, mExtension);
+    }
+
     public String getLogFileParentDir() {
         ArrayList<String> elements = new ArrayList<String>();
         elements.add(mPrefix);

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -167,6 +167,10 @@ public class SecorConfig {
         return getString("secor.message.parser.class");
     }
 
+    public String getUploadManagerClass() {
+        return getString("secor.upload.manager.class");
+    }
+
     public int getTopicPartitionForgetSeconds() {
         return getInt("secor.topic_partition.forget.seconds");
     }
@@ -185,6 +189,14 @@ public class SecorConfig {
 
     public String getAwsSecretKey() {
         return getString("aws.secret.key");
+    }
+
+    public String getAwsEndpoint() {
+        return getString("aws.endpoint");
+    }
+
+    public String getAwsRegion() {
+        return getString("aws.region");
     }
 
     public String getQuboleApiToken() {

--- a/src/main/java/com/pinterest/secor/consumer/Consumer.java
+++ b/src/main/java/com/pinterest/secor/consumer/Consumer.java
@@ -23,6 +23,7 @@ import com.pinterest.secor.message.Message;
 import com.pinterest.secor.message.ParsedMessage;
 import com.pinterest.secor.parser.MessageParser;
 import com.pinterest.secor.uploader.Uploader;
+import com.pinterest.secor.uploader.UploadManager;
 import com.pinterest.secor.reader.MessageReader;
 import com.pinterest.secor.util.ReflectionUtil;
 import com.pinterest.secor.writer.MessageWriter;
@@ -66,9 +67,11 @@ public class Consumer extends Thread {
         mOffsetTracker = new OffsetTracker();
         mMessageReader = new MessageReader(mConfig, mOffsetTracker);
         FileRegistry fileRegistry = new FileRegistry(mConfig);
+        UploadManager uploadManager = ReflectionUtil.createUploadManager(mConfig.getUploadManagerClass(), mConfig);
+
+        mUploader = new Uploader(mConfig, mOffsetTracker, fileRegistry, uploadManager);
         mMessageWriter = new MessageWriter(mConfig, mOffsetTracker, fileRegistry);
         mMessageParser = ReflectionUtil.createMessageParser(mConfig.getMessageParserClass(), mConfig);
-        mUploader = new Uploader(mConfig, mOffsetTracker, fileRegistry);
         mUnparsableMessages = 0.;
     }
 

--- a/src/main/java/com/pinterest/secor/uploader/FutureHandle.java
+++ b/src/main/java/com/pinterest/secor/uploader/FutureHandle.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import java.util.concurrent.Future;
+
+/**
+ * Wraps a Future. `get` blocks until the underlying Future completes.
+ *
+ * @author Liam Stewart (liam.stewart@gmail.com)
+ */
+public class FutureHandle<T> implements Handle<T> {
+    private Future<T> mFuture;
+
+    public FutureHandle(Future<T> f) {
+        mFuture = f;
+    }
+
+    public T get() throws Exception {
+        return mFuture.get();
+    }
+}

--- a/src/main/java/com/pinterest/secor/uploader/HadoopS3UploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/HadoopS3UploadManager.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.*;
+import com.pinterest.secor.util.FileUtil;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.Future;
+
+/**
+ * Manages uploads to S3 using the Hadoop API.
+ *
+ * @author Pawel Garbacki (pawel@pinterest.com)
+ */
+public class HadoopS3UploadManager extends UploadManager {
+    private static final Logger LOG = LoggerFactory.getLogger(HadoopS3UploadManager.class);
+
+    private static final ExecutorService executor = Executors.newFixedThreadPool(256);
+
+    public HadoopS3UploadManager(SecorConfig config) {
+        super(config);
+    }
+
+    public Handle<?> upload(LogFilePath localPath) throws Exception {
+        String s3Prefix = "s3n://" + mConfig.getS3Bucket() + "/" + mConfig.getS3Path();
+        LogFilePath s3Path = localPath.withPrefix(s3Prefix);
+        final String localLogFilename = localPath.getLogFilePath();
+        final String s3LogFilename = s3Path.getLogFilePath();
+        LOG.info("uploading file {} to {}", localLogFilename, s3LogFilename);
+
+        final Future<?> f = executor.submit(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    FileUtil.moveToS3(localLogFilename, s3LogFilename);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        return new FutureHandle(f);
+    }
+}

--- a/src/main/java/com/pinterest/secor/uploader/Handle.java
+++ b/src/main/java/com/pinterest/secor/uploader/Handle.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+/**
+ * Simple generic wrapper interface.
+ *
+ * @author Liam Stewart (liam.stewart@gmail.com)
+ */
+public interface Handle<T> {
+    public T get() throws Exception;
+}

--- a/src/main/java/com/pinterest/secor/uploader/S3UploadHandle.java
+++ b/src/main/java/com/pinterest/secor/uploader/S3UploadHandle.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.services.s3.transfer.model.UploadResult;
+
+/**
+ * Wraps an Upload being managed by the AWS SDK TransferManager. `get`
+ * blocks until the upload completes.
+ *
+ * @author Liam Stewart (liam.stewart@gmail.com)
+ */
+public class S3UploadHandle implements Handle<UploadResult> {
+    private Upload mUpload;
+
+    public S3UploadHandle(Upload u) {
+        mUpload = u;
+    }
+
+    public UploadResult get() throws Exception {
+        return mUpload.waitForUploadResult();
+    }
+}

--- a/src/main/java/com/pinterest/secor/uploader/S3UploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/S3UploadManager.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.*;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.services.s3.transfer.TransferManager;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+/**
+ * Manages uploads to S3 using the TransferManager class from the AWS
+ * SDK.
+ *
+ * It will use the aws.access.key and aws.secret.key configuration
+ * settings if they are non-empty; otherwise, it will use the SDK's
+ * default credential provider chain (supports environment variables,
+ * system properties, credientials file, and IAM credentials).
+ *
+ * @author Liam Stewart (liam.stewart@gmail.com)
+ */
+public class S3UploadManager extends UploadManager {
+    private static final Logger LOG = LoggerFactory.getLogger(S3UploadManager.class);
+
+    private TransferManager mManager;
+
+    public S3UploadManager(SecorConfig config) {
+        super(config);
+
+        String accessKey = mConfig.getAwsAccessKey();
+        String secretKey = mConfig.getAwsSecretKey();
+        String endpoint = mConfig.getAwsEndpoint();
+        String region = mConfig.getAwsRegion();
+        AmazonS3 client;
+
+        if (accessKey.isEmpty() || secretKey.isEmpty()) {
+            client = new AmazonS3Client();
+        } else {
+            client = new AmazonS3Client(new BasicAWSCredentials(accessKey, secretKey));
+        }
+
+        if (!endpoint.isEmpty()) {
+            client.setEndpoint(endpoint);
+        } else if (!region.isEmpty()) {
+            client.setRegion(Region.getRegion(Regions.fromName(region)));
+        }
+
+        mManager = new TransferManager(client);
+    }
+
+    public Handle<?> upload(LogFilePath localPath) throws Exception {
+        String s3Bucket = mConfig.getS3Bucket();
+        String s3Key = localPath.withPrefix(mConfig.getS3Path()).getLogFilePath();
+        File localFile = new File(localPath.getLogFilePath());
+
+        LOG.info("uploading file {} to s3://{}/{}", localFile, s3Bucket, s3Key);
+
+        Upload upload = mManager.upload(s3Bucket, s3Key, localFile);
+        return new S3UploadHandle(upload);
+    }
+}

--- a/src/main/java/com/pinterest/secor/uploader/UploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/UploadManager.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.*;
+
+/**
+ * Manages uploads.
+ *
+ * @author Liam Stewart (liam.stewart@gmail.com)
+ */
+public abstract class UploadManager {
+    protected SecorConfig mConfig;
+
+    public UploadManager(SecorConfig config) {
+        mConfig = config;
+    }
+
+    public abstract Handle<?> upload(LogFilePath localPath) throws Exception;
+}

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -33,9 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 /**
  * Uploader applies a set of policies to determine if any of the locally stored files should be
@@ -46,47 +43,27 @@ import java.util.concurrent.Future;
 public class Uploader {
     private static final Logger LOG = LoggerFactory.getLogger(Uploader.class);
 
-    private static final ExecutorService executor = Executors.newFixedThreadPool(256);
-
     private SecorConfig mConfig;
     private OffsetTracker mOffsetTracker;
     private FileRegistry mFileRegistry;
     private ZookeeperConnector mZookeeperConnector;
+    private UploadManager mUploadManager;
 
-    public Uploader(SecorConfig config, OffsetTracker offsetTracker, FileRegistry fileRegistry) {
-        this(config, offsetTracker, fileRegistry, new ZookeeperConnector(config));
+    public Uploader(SecorConfig config, OffsetTracker offsetTracker, FileRegistry fileRegistry,
+                    UploadManager uploadManager) {
+        this(config, offsetTracker, fileRegistry, uploadManager,
+             new ZookeeperConnector(config));
     }
 
     // For testing use only.
     public Uploader(SecorConfig config, OffsetTracker offsetTracker, FileRegistry fileRegistry,
+                    UploadManager uploadManager,
                     ZookeeperConnector zookeeperConnector) {
         mConfig = config;
         mOffsetTracker = offsetTracker;
         mFileRegistry = fileRegistry;
+        mUploadManager = uploadManager;
         mZookeeperConnector = zookeeperConnector;
-    }
-
-    private Future<?> upload(LogFilePath localPath) throws Exception {
-        String s3Prefix = "s3n://" + mConfig.getS3Bucket() + "/" + mConfig.getS3Path();
-        LogFilePath s3Path = new LogFilePath(s3Prefix, localPath.getTopic(),
-                                             localPath.getPartitions(),
-                                             localPath.getGeneration(),
-                                             localPath.getKafkaPartition(),
-                                             localPath.getOffset(),
-                                             localPath.getExtension());
-        final String localLogFilename = localPath.getLogFilePath();
-        final String s3LogFilename = s3Path.getLogFilePath();
-        LOG.info("uploading file {} to {}", localLogFilename, s3LogFilename);
-        return executor.submit(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    FileUtil.moveToS3(localLogFilename, s3LogFilename);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
     }
 
     private void uploadFiles(TopicPartition topicPartition) throws Exception {
@@ -112,12 +89,12 @@ public class Uploader {
                 // Deleting writers closes their streams flushing all pending data to the disk.
                 mFileRegistry.deleteWriters(topicPartition);
                 Collection<LogFilePath> paths = mFileRegistry.getPaths(topicPartition);
-                List<Future<?>> uploadFutures = new ArrayList<Future<?>>();
+                List<Handle<?>> uploadHandles = new ArrayList<Handle<?>>();
                 for (LogFilePath path : paths) {
-                    uploadFutures.add(upload(path));
+                    uploadHandles.add(mUploadManager.upload(path));
                 }
-                for (Future<?> uploadFuture : uploadFutures) {
-                    uploadFuture.get();
+                for (Handle<?> uploadHandle : uploadHandles) {
+                    uploadHandle.get();
                 }
                 mFileRegistry.deleteTopicPartition(topicPartition);
                 mZookeeperConnector.setCommittedOffsetCount(topicPartition, lastSeenOffset + 1);

--- a/src/main/java/com/pinterest/secor/util/ReflectionUtil.java
+++ b/src/main/java/com/pinterest/secor/util/ReflectionUtil.java
@@ -23,6 +23,7 @@ import com.pinterest.secor.io.FileReader;
 import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.io.FileReaderWriterFactory;
 import com.pinterest.secor.parser.MessageParser;
+import com.pinterest.secor.uploader.UploadManager;
 import org.apache.hadoop.io.compress.CompressionCodec;
 
 /**
@@ -33,6 +34,30 @@ import org.apache.hadoop.io.compress.CompressionCodec;
  * @author Silas Davis (github-code@silasdavis.net)
  */
 public class ReflectionUtil {
+    /**
+     * Create an UploadManager from its fully qualified class name.
+     *
+     * The class passed in by name must be assignable to UploadManager
+     * and have 1-parameter constructor accepting a SecorConfig.
+     *
+     * See the secor.upload.manager.class config option.
+     *
+     * @param className The class name of a subclass of UploadManager
+     * @param config The SecorCondig to initialize the UploadManager with
+     * @return an UploadManager instance with the runtime type of the class passed by name
+     * @throws Exception
+     */
+    public static UploadManager createUploadManager(String className,
+                                                    SecorConfig config) throws Exception {
+        Class<?> clazz = Class.forName(className);
+        if (!UploadManager.class.isAssignableFrom(clazz)) {
+            throw new IllegalArgumentException(String.format("The class '%s' is not assignable to '%s'.",
+                    className, UploadManager.class.getName()));
+        }
+
+        // Assume that subclass of UploadManager has a constructor with the same signature as UploadManager
+        return (UploadManager) clazz.getConstructor(SecorConfig.class).newInstance(config);
+    }
 
     /**
      * Create a MessageParser from it's fully qualified class name.

--- a/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
+++ b/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
@@ -49,8 +49,10 @@ public class UploaderTest extends TestCase {
         private FileReader mReader;
 
         public TestUploader(SecorConfig config, OffsetTracker offsetTracker,
-                FileRegistry fileRegistry, ZookeeperConnector zookeeperConnector) {
-            super(config, offsetTracker, fileRegistry, zookeeperConnector);
+                            FileRegistry fileRegistry,
+                            UploadManager uploadManager,
+                            ZookeeperConnector zookeeperConnector) {
+            super(config, offsetTracker, fileRegistry, uploadManager, zookeeperConnector);
             mReader = Mockito.mock(FileReader.class);
         }
 
@@ -73,6 +75,7 @@ public class UploaderTest extends TestCase {
     private OffsetTracker mOffsetTracker;
     private FileRegistry mFileRegistry;
     private ZookeeperConnector mZookeeperConnector;
+    private UploadManager mUploadManager;
 
     private TestUploader mUploader;
 
@@ -99,8 +102,10 @@ public class UploaderTest extends TestCase {
         Mockito.when(mFileRegistry.getTopicPartitions()).thenReturn(
                 topicPartitions);
 
+        mUploadManager = new HadoopS3UploadManager(mConfig);
+
         mZookeeperConnector = Mockito.mock(ZookeeperConnector.class);
-        mUploader = new TestUploader(mConfig, mOffsetTracker, mFileRegistry,
+        mUploader = new TestUploader(mConfig, mOffsetTracker, mFileRegistry, mUploadManager,
                 mZookeeperConnector);
     }
 


### PR DESCRIPTION
This provides more flexibility for credentials and region choice. The
core upload functionality has been moved out of `Uploader` and into
`UploadManager` implementations. The manager to use can be set through
the configuration file.

Similar to https://github.com/pinterest/secor/pull/98 but without the Hadoop layer.