### PR TITLE
    Adding support for hourly s3 data ingestion from secor:

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -86,6 +86,22 @@ secor.offsets.per.partition=10000000
 # How long does it take for secor to forget a topic partition. Applies to stats generation only.
 secor.topic_partition.forget.seconds=600
 
+# Setting the partitioner to use hourly partition
+# By default, the partitioner will do daily partition, so the data will be 
+# written into 
+#       s3n://.../topic/dt=2015-07-07/
+# If this parameter is set to true, the data will be written into
+#       s3n://.../topic/dt=2015-07-07/hr=02
+# The hour folder ranges from 00 to 23
+# partitioner.granularity.hour=true
+
+# During partition finalization, the finalizer will start from the last
+# time partition (e.g. dt=2015-07-17) and traverse backwards for n 
+# partition periods (e.g. dt=2015-07-16, dt=2015-07-15 ...)
+# This parameter controls how many partition periods to traverse back
+# The default is 10
+# secor.finalizer.lookback.periods=10
+
 # If greater than 0, upon starup Secor will clean up directories and files under secor.local.path
 # that are older than this value.
 secor.local.log.delete.age.hours=-1

--- a/src/main/config/secor.dev.hr.partition.properties
+++ b/src/main/config/secor.dev.hr.partition.properties
@@ -1,0 +1,11 @@
+include=secor.dev.properties
+
+secor.kafka.group=secor_hr_partition
+secor.message.parser.class=com.pinterest.secor.parser.ThriftMessageParser
+
+secor.s3.path=secor_dev/hr_partition
+secor.local.path=/tmp/secor_dev/message_logs/hr_partition
+
+message.timestamp.using.hour=true
+
+ostrich.port=9998

--- a/src/main/config/secor.dev.hr.partition.properties
+++ b/src/main/config/secor.dev.hr.partition.properties
@@ -6,6 +6,6 @@ secor.message.parser.class=com.pinterest.secor.parser.ThriftMessageParser
 secor.s3.path=secor_dev/hr_partition
 secor.local.path=/tmp/secor_dev/message_logs/hr_partition
 
-message.timestamp.using.hour=true
+partitioner.granularity.hour=true
 
 ostrich.port=9998

--- a/src/main/config/secor.dev.properties
+++ b/src/main/config/secor.dev.properties
@@ -19,6 +19,6 @@ zookeeper.quorum=localhost:2181
 # Upload policies.
 # 10K
 secor.max.file.size.bytes=10000
-# 1 minute
-secor.max.file.age.seconds=60
+# 10 seconds
+secor.max.file.age.seconds=10
 

--- a/src/main/config/secor.prod.properties
+++ b/src/main/config/secor.prod.properties
@@ -37,5 +37,6 @@ zookeeper.quorum=
 # 200MB
 secor.max.file.size.bytes=200000000
 # 1 hour
+# for hourly ingestion/finalization, set this property to smaller value, e.g. 1800
 secor.max.file.age.seconds=3600
 

--- a/src/main/java/com/pinterest/secor/common/LogFilePath.java
+++ b/src/main/java/com/pinterest/secor/common/LogFilePath.java
@@ -42,13 +42,13 @@ import java.util.Arrays;
  * @author Pawel Garbacki (pawel@pinterest.com)
  */
 public class LogFilePath {
-    private String mPrefix;
-    private String mTopic;
-    private String[] mPartitions;
-    private int mGeneration;
-    private int mKafkaPartition;
-    private long mOffset;
-    private String mExtension;
+    private final String mPrefix;
+    private final String mTopic;
+    private final String[] mPartitions;
+    private final int mGeneration;
+    private final int mKafkaPartition;
+    private final long mOffset;
+    private final String mExtension;
 
     public LogFilePath(String prefix, int generation, long lastCommittedOffset,
                        ParsedMessage message, String extension) {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -215,6 +215,14 @@ public class SecorConfig {
       return getBoolean("message.timestamp.using.hour", false);
     }
 
+    public int getFinalizerLagSecond() {
+        return getInt("finalizer.lag.second", 3600);
+    }
+
+    public int getFinalizerLookbackPeriods() {
+        return getInt("finalizer.lookback.periods", 10);
+    }
+
     public String getHivePrefix() { 
         return getString("secor.hive.prefix"); 
     }
@@ -256,12 +264,12 @@ public class SecorConfig {
         return mProperties.getInt(name);
     }
 
-    private boolean getBoolean(String name, boolean required) {
-      if (required) {
-        checkProperty(name);
-        return mProperties.getBoolean(name);
-      }
-      return mProperties.getBoolean(name, false);
+    private int getInt(String name, int defaultValue) {
+        return mProperties.getInt(name, defaultValue);
+    }
+
+    private boolean getBoolean(String name, boolean defaultValue) {
+        return mProperties.getBoolean(name, defaultValue);
     }
 
     private long getLong(String name) {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -211,16 +211,8 @@ public class SecorConfig {
         return getString("message.timestamp.input.pattern");
     }
 
-    public boolean getMessageTimestampUsingHour() {
-      return getBoolean("message.timestamp.using.hour", false);
-    }
-
-    public int getFinalizerLagSecond() {
-        return getInt("finalizer.lag.second", 3600);
-    }
-
     public int getFinalizerLookbackPeriods() {
-        return getInt("finalizer.lookback.periods", 10);
+        return getInt("secor.finalizer.lookback.periods", 10);
     }
 
     public String getHivePrefix() { 
@@ -247,6 +239,10 @@ public class SecorConfig {
         return getString("secor.zookeeper.path");
     }
 
+    public boolean getBoolean(String name, boolean defaultValue) {
+        return mProperties.getBoolean(name, defaultValue);
+    }
+
     private void checkProperty(String name) {
         if (!mProperties.containsKey(name)) {
             throw new RuntimeException("Failed to find required configuration option '" +
@@ -266,10 +262,6 @@ public class SecorConfig {
 
     private int getInt(String name, int defaultValue) {
         return mProperties.getInt(name, defaultValue);
-    }
-
-    private boolean getBoolean(String name, boolean defaultValue) {
-        return mProperties.getBoolean(name, defaultValue);
     }
 
     private long getLong(String name) {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -211,6 +211,10 @@ public class SecorConfig {
         return getString("message.timestamp.input.pattern");
     }
 
+    public boolean getMessageTimestampUsingHour() {
+      return getBoolean("message.timestamp.using.hour", false);
+    }
+
     public String getHivePrefix() { 
         return getString("secor.hive.prefix"); 
     }
@@ -250,6 +254,14 @@ public class SecorConfig {
     private int getInt(String name) {
         checkProperty(name);
         return mProperties.getInt(name);
+    }
+
+    private boolean getBoolean(String name, boolean required) {
+      if (required) {
+        checkProperty(name);
+        return mProperties.getBoolean(name);
+      }
+      return mProperties.getBoolean(name, false);
     }
 
     private long getLong(String name) {

--- a/src/main/java/com/pinterest/secor/main/TestLogMessageProducerMain.java
+++ b/src/main/java/com/pinterest/secor/main/TestLogMessageProducerMain.java
@@ -63,6 +63,19 @@ public class TestLogMessageProducerMain {
                 .withArgName("<type>")
                 .withType(String.class)
                 .create("type"));
+        options.addOption(OptionBuilder.withLongOpt("broker")
+                .withDescription("broker string, e.g. localhost:9092")
+                .hasArg()
+                .withArgName("<broker>")
+                .withType(String.class)
+                .create("broker"));
+        options.addOption(OptionBuilder.withLongOpt("timeshift")
+            .withDescription("message timestamp adjustment in seconds, it will be deducted" +
+                " from current time")
+            .hasArg()
+            .withArgName("<timeshift>")
+            .withType(Number.class)
+            .create("timeshift"));
 
         CommandLineParser parser = new GnuParser();
         return parser.parse(options, args);
@@ -74,9 +87,13 @@ public class TestLogMessageProducerMain {
             String topic = commandLine.getOptionValue("topic");
             int messages = ((Number) commandLine.getParsedOptionValue("messages")).intValue();
             int producers = ((Number) commandLine.getParsedOptionValue("producers")).intValue();
+            String broker = commandLine.getOptionValue("broker");
             String type = commandLine.getOptionValue("type");
+            Number timeshiftNumber = ((Number)commandLine.getParsedOptionValue("timeshift"));
+            int timeshift = timeshiftNumber == null ? 0 : timeshiftNumber.intValue();
             for (int i = 0; i < producers; ++i) {
-                TestLogMessageProducer producer = new TestLogMessageProducer(topic, messages, type);
+                TestLogMessageProducer producer = new TestLogMessageProducer(
+                     topic, messages, type, broker, timeshift);
                 producer.start();
             }
         } catch (Throwable t) {

--- a/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
+++ b/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
@@ -25,12 +25,10 @@ import org.apache.hadoop.io.compress.CompressionCodec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Stack;
 
 /**
  * Partition finalizer writes _SUCCESS files to date partitions that very likely won't be receiving
@@ -41,13 +39,13 @@ import java.util.regex.Pattern;
 public class PartitionFinalizer {
     private static final Logger LOG = LoggerFactory.getLogger(PartitionFinalizer.class);
 
-    private SecorConfig mConfig;
-    private ZookeeperConnector mZookeeperConnector;
-    private TimestampedMessageParser mMessageParser;
-    private KafkaClient mKafkaClient;
-    private QuboleClient mQuboleClient;
-    private String mFileExtension;
-    private final boolean usingHourly;
+    private final SecorConfig mConfig;
+    private final ZookeeperConnector mZookeeperConnector;
+    private final TimestampedMessageParser mMessageParser;
+    private final KafkaClient mKafkaClient;
+    private final QuboleClient mQuboleClient;
+    private final String mFileExtension;
+    private final int mLookbackPeriods;
 
     public PartitionFinalizer(SecorConfig config) throws Exception {
         mConfig = config;
@@ -62,216 +60,123 @@ public class PartitionFinalizer {
         } else {
             mFileExtension = "";
         }
-        usingHourly = config.getMessageTimestampUsingHour();
+        mLookbackPeriods = config.getFinalizerLookbackPeriods();
+        LOG.info("Lookback periods: " + mLookbackPeriods);
     }
 
-    private long getLastTimestampMillis(TopicPartition topicPartition) throws Exception {
-        Message message = mKafkaClient.getLastMessage(topicPartition);
-        if (message == null) {
-            // This will happen if no messages have been posted to the given topic partition.
-            LOG.error("No message found for topic {} partition {}" + topicPartition.getTopic(), topicPartition.getPartition());
-            return -1;
-        }
-        return mMessageParser.extractTimestampMillis(message);
-    }
-
-    private long getLastTimestampMillis(String topic) throws Exception {
+    private String[] getFinalizedUptoPartitions(String topic) throws Exception {
         final int numPartitions = mKafkaClient.getNumPartitions(topic);
-        long max_timestamp = Long.MIN_VALUE;
+        List<Message> lastMessages = new ArrayList<Message>(numPartitions);
+        List<Message> committedMessages = new ArrayList<Message>(numPartitions);
         for (int partition = 0; partition < numPartitions; ++partition) {
             TopicPartition topicPartition = new TopicPartition(topic, partition);
-            long timestamp = getLastTimestampMillis(topicPartition);
-            if (timestamp > max_timestamp) {
-                max_timestamp = timestamp;
-            }
-        }
-        if (max_timestamp == Long.MIN_VALUE) {
-            return -1;
-        }
-        return max_timestamp;
-    }
-
-    private long getCommittedTimestampMillis(TopicPartition topicPartition) throws Exception {
-        Message message = mKafkaClient.getCommittedMessage(topicPartition);
-        if (message == null) {
-            LOG.error("No message found for topic {} partition {}", topicPartition.getTopic(), topicPartition.getPartition());
-            return -1;
-        }
-        return mMessageParser.extractTimestampMillis(message);
-    }
-
-    private long getCommittedTimestampMillis(String topic) throws Exception {
-        final int numPartitions = mKafkaClient.getNumPartitions(topic);
-        long minTimestamp = Long.MAX_VALUE;
-        for (int partition = 0; partition < numPartitions; ++partition) {
-            TopicPartition topicPartition = new TopicPartition(topic, partition);
-            long timestamp = getCommittedTimestampMillis(topicPartition);
-            if (timestamp == -1) {
-                return -1;
-            } else {
-                if (timestamp < minTimestamp) {
-                    minTimestamp = timestamp;
-                }
-            }
-        }
-        if (minTimestamp == Long.MAX_VALUE) {
-            return -1;
-        }
-        return minTimestamp;
-    }
-
-    private NavigableSet<Calendar> getPartitions(String topic) throws IOException, ParseException {
-        final String s3Prefix = "s3n://" + mConfig.getS3Bucket() + "/" + mConfig.getS3Path();
-        String[] partitions = usingHourly ? new String[]{"dt=", "hr="} : new String[]{"dt="};
-        LogFilePath logFilePath = new LogFilePath(s3Prefix, topic, partitions,
-            mConfig.getGeneration(), 0, 0, mFileExtension);
-        String parentDir = logFilePath.getLogFileParentDir();
-        String[] partitionDirs = FileUtil.list(parentDir);
-        if (usingHourly) {
-            List<String> dirs = new ArrayList<String>();
-            for (String partionDir : partitionDirs) {
-                dirs.addAll(Arrays.asList(FileUtil.list(partionDir)));
-            }
-            partitionDirs = dirs.toArray(new String[dirs.size()]);
-        }
-        String patternStr = ".*/dt=(\\d\\d\\d\\d-\\d\\d-\\d\\d)";
-        if (usingHourly) {
-            patternStr += "/hr=(\\d\\d)";
-        }
-        patternStr += "$";
-        LOG.info("patternStr: " + patternStr);
-        Pattern pattern = Pattern.compile(patternStr);
-        TreeSet<Calendar> result = new TreeSet<Calendar>();
-        for (String partitionDir : partitionDirs) {
-            Matcher matcher = pattern.matcher(partitionDir);
-            if (matcher.find()) {
-                String date = matcher.group(1);
-                String hour = usingHourly ? matcher.group(2) : "00";
-                SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd-HH");
-                format.setTimeZone(TimeZone.getTimeZone("UTC"));
-                Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-                calendar.setTime(format.parse(date + "-" + hour));
-                result.add(calendar);
-            }
-        }
-        return result;
-    }
-
-    private void finalizePartitionsUpTo(String topic, Calendar calendar) throws IOException,
-            ParseException, InterruptedException {
-        NavigableSet<Calendar> partitionDates =
-            getPartitions(topic).headSet(calendar, true).descendingSet();
-        final String s3Prefix = "s3n://" + mConfig.getS3Bucket() + "/" + mConfig.getS3Path();
-        SimpleDateFormat dtFormat = new SimpleDateFormat("yyyy-MM-dd");
-        SimpleDateFormat hrFormat = new SimpleDateFormat("HH");
-        dtFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        hrFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        NavigableSet<Calendar> finishedDates = new TreeSet<Calendar>();
-        for (Calendar partition : partitionDates) {
-            String dtPartitionStr = dtFormat.format(partition.getTime());
-            String hrPartitionStr = hrFormat.format(partition.getTime());
-            String[] partitions = usingHourly
-                                  ? new String[]{"dt=" + dtPartitionStr, "hr=" + hrPartitionStr}
-                                  : new String[]{"dt=" + dtPartitionStr};
-            LogFilePath logFilePath = new LogFilePath(s3Prefix, topic, partitions,
-                mConfig.getGeneration(), 0, 0, mFileExtension);
-            String logFileDir = logFilePath.getLogFileDir();
-            assert FileUtil.exists(logFileDir) : "FileUtil.exists(" + logFileDir + ")";
-            String successFilePath = logFileDir + "/_SUCCESS";
-            if (FileUtil.exists(successFilePath)) {
-                LOG.info("File exist already, short circuit return. " + successFilePath);
-                 break;
-            }
-            try {
-                String parStr = "dt='" + dtPartitionStr + "'";
-                if (usingHourly) {
-                    parStr += ", hr='" + hrPartitionStr + "'";
-                }
-                String hivePrefix = null;
-                try {
-                    hivePrefix = mConfig.getHivePrefix();
-                } catch (RuntimeException ex) {
-                    LOG.warn("HivePrefix is not defined.  Skip hive registration");
-                }
-                if (hivePrefix != null) {
-                    mQuboleClient.addPartition(hivePrefix + topic, parStr);
-                }
-            } catch (Exception e) {
-                LOG.error("failed to finalize topic " + topic
-                        + " partition dt=" + dtPartitionStr + " hr=" + hrPartitionStr,
-                        e);
+            Message lastMessage = mKafkaClient.getLastMessage(topicPartition);
+            Message committedMessage = mKafkaClient.getCommittedMessage(topicPartition);
+            if (lastMessage == null || committedMessage == null) {
+                // This will happen if no messages have been posted to the given topic partition.
+                LOG.error("For topic {} partition {}, lastMessage: {}, commmitted: {}",
+                    topicPartition.getTopic(), topicPartition.getPartition(),
+                    lastMessage, committedMessage);
                 continue;
             }
-            LOG.info("touching file {}", successFilePath);
-            FileUtil.touch(successFilePath);
-
-
-            // We need to mark the successFile for the dt folder as well
-            if (usingHourly) {
-                Calendar yesterday = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-                yesterday.setTimeInMillis(partition.getTimeInMillis());
-                yesterday.add(Calendar.DAY_OF_MONTH, -1);
-                finishedDates.add(yesterday);
-            }
+            lastMessages.add(lastMessage);
+            committedMessages.add(committedMessage);
         }
-
-        // Reverse order to enable short circuit return
-        finishedDates = finishedDates.descendingSet();
-        for (Calendar partition : finishedDates) {
-            String dtPartitionStr = dtFormat.format(partition.getTime());
-            String[] partitions = new String[]{"dt=" + dtPartitionStr};
-            LogFilePath logFilePath = new LogFilePath(s3Prefix, topic, partitions,
-                mConfig.getGeneration(), 0, 0, mFileExtension);
-            String logFileDir = logFilePath.getLogFileDir();
-            String successFilePath = logFileDir + "/_SUCCESS";
-            if (FileUtil.exists(successFilePath)) {
-                LOG.info("File exist already, short circuit return. " + successFilePath);
-                break;
-            }
-            LOG.info("touching file " + successFilePath);
-            FileUtil.touch(successFilePath);
-        }
+        return mMessageParser.getFinalizedUptoPartitions(lastMessages, committedMessages);
     }
 
-    /**
-     * Get finalized timestamp for a given topic partition. Finalized timestamp is the current time
-     * if the last offset for that topic partition has been committed earlier than an hour ago.
-     * Otherwise, finalized timestamp is the committed timestamp.
-     *
-     * @param topicPartition The topic partition for which we want to compute the finalized
-     *                       timestamp.
-     * @return The finalized timestamp for the topic partition.
-     * @throws Exception
-     */
-    private long getFinalizedTimestampMillis(TopicPartition topicPartition) throws Exception {
-        long lastTimestamp = getLastTimestampMillis(topicPartition);
-        long committedTimestamp = getCommittedTimestampMillis(topicPartition);
-        long now = System.currentTimeMillis();
-        if (lastTimestamp == committedTimestamp && (now - lastTimestamp) > 3600 * 1000) {
-            return now;
-        }
-        return committedTimestamp;
-    }
+    private void finalizePartitionsUpTo(String topic, String[] partitions) throws Exception {
+        final String s3Prefix = "s3n://" + mConfig.getS3Bucket() + "/" + mConfig.getS3Path();
 
-    private long getFinalizedTimestampMillis(String topic) throws Exception {
-        final int numPartitions = mKafkaClient.getNumPartitions(topic);
-        long minTimestamp = Long.MAX_VALUE;
-        for (int partition = 0; partition < numPartitions; ++partition) {
-            TopicPartition topicPartition = new TopicPartition(topic, partition);
-            long timestamp = getFinalizedTimestampMillis(topicPartition);
-            LOG.info("finalized timestamp for topic {} partition {} is {}", topic, partition, timestamp);
-            if (timestamp == -1) {
-                return -1;
-            } else {
-                if (timestamp < minTimestamp) {
-                    minTimestamp = timestamp;
+        // Walk through each dimension of the partitions array
+        // First finalize the hourly partitions, and then move on to daily partitions
+        for (int dim = partitions.length; dim > 0; dim--) {
+            String[] uptoPartitions = Arrays.copyOf(partitions, dim);
+            LOG.info("Finalize up to (but not include) {} for dim: {}", uptoPartitions, dim);
+
+            String[] previous = mMessageParser.getPreviousPartitions(uptoPartitions);
+            Stack<String[]> toBeFinalized = new Stack<String[]>();
+            // Walk backwards to collect all partitions which are previous to the upTo partition
+            // Do not include the upTo partition
+            // Stop at the first partition which already have the SUCCESS file
+            for (int i = 0; i < mLookbackPeriods; i++) {
+                LOG.info("Looking for partition: " + Arrays.toString(previous));
+                LogFilePath logFilePath = new LogFilePath(s3Prefix, topic, previous,
+                    mConfig.getGeneration(), 0, 0, mFileExtension);
+                String logFileDir = logFilePath.getLogFileDir();
+                if (FileUtil.exists(logFileDir)) {
+                    String successFilePath = logFileDir + "/_SUCCESS";
+                    if (FileUtil.exists(successFilePath)) {
+                        LOG.info(
+                            "SuccessFile exist already, short circuit return. " + successFilePath);
+                        break;
+                    }
+                    LOG.info("Folder {} exists and ready to be finalized.", logFileDir);
+                    toBeFinalized.push(previous);
+                } else {
+                    LOG.info("Folder {} doesn't exist, skip", logFileDir);
                 }
+                previous = mMessageParser.getPreviousPartitions(previous);
+            }
+
+            LOG.info("To be finalized partitions: {}", toBeFinalized);
+            if (toBeFinalized.isEmpty()) {
+                LOG.warn("There is no partitions to be finalized for dim: {}", dim);
+                continue;
+            }
+
+            // Now walk forward the collected partitions to do the finalization
+            // Note we are deliberately walking backwards and then forwards to make sure we don't
+            // end up in a situation that a later date partition is finalized and then the system
+            // crashes (which creates unfinalized partition folders in between)
+            while (!toBeFinalized.isEmpty()) {
+                String[] current = toBeFinalized.pop();
+                LOG.info("Finalizing partition: " + Arrays.toString(current));
+                // We only perform hive registration on the last dimension of the partition array
+                // i.e. only do hive registration for the hourly folder, but not for the daily
+                if (dim == partitions.length) {
+                    try {
+                        StringBuilder sb = new StringBuilder();
+                        for (int i = 0; i < current.length; i++) {
+                            String par = current[i];
+                            // We expect the partition array in the form of key=value if
+                            // they need to go through hive registration
+                            String[] parts = par.split("=");
+                            assert parts.length == 2 : "wrong partition format: " + par;
+                            if (i > 0) {
+                                sb.append(",");
+                            }
+                            sb.append(parts[0]);
+                            sb.append("='");
+                            sb.append(parts[1]);
+                            sb.append("'");
+                        }
+                        LOG.info("Hive partition string: " + sb);
+                        String hivePrefix = null;
+                        try {
+                            hivePrefix = mConfig.getHivePrefix();
+                        } catch (RuntimeException ex) {
+                            LOG.warn("HivePrefix is not defined.  Skip hive registration");
+                        }
+                        if (hivePrefix != null) {
+                            mQuboleClient.addPartition(hivePrefix + topic, sb.toString());
+                        }
+                    } catch (Exception e) {
+                        LOG.error("failed to finalize topic " + topic, e);
+                        continue;
+                    }
+                }
+
+                // Generate the SUCCESS file at the end
+                LogFilePath logFilePath = new LogFilePath(s3Prefix, topic, current,
+                    mConfig.getGeneration(), 0, 0, mFileExtension);
+                String logFileDir = logFilePath.getLogFileDir();
+                String successFilePath = logFileDir + "/_SUCCESS";
+
+                LOG.info("touching file {}", successFilePath);
+                FileUtil.touch(successFilePath);
             }
         }
-        if (minTimestamp == Long.MAX_VALUE) {
-            return -1;
-        }
-        return minTimestamp;
     }
 
     public void finalizePartitions() throws Exception {
@@ -281,17 +186,10 @@ public class PartitionFinalizer {
                 LOG.info("skipping topic {}", topic);
             } else {
                 LOG.info("finalizing topic {}", topic);
-                long finalizedTimestampMillis = getFinalizedTimestampMillis(topic);
-                LOG.info("finalized timestamp for topic {} is {}", topic , finalizedTimestampMillis);
-                if (finalizedTimestampMillis != -1) {
-                    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
-                    calendar.setTimeInMillis(finalizedTimestampMillis);
-                    if (!usingHourly) {
-                        calendar.add(Calendar.DAY_OF_MONTH, -1);
-                    }
-                    // Introduce a lag of one hour.
-                    calendar.add(Calendar.HOUR, -1);
-                    finalizePartitionsUpTo(topic, calendar);
+                String[] partitions = getFinalizedUptoPartitions(topic);
+                LOG.info("finalized timestamp for topic {} is {}", topic , partitions);
+                if (partitions != null) {
+                    finalizePartitionsUpTo(topic, partitions);
                 }
             }
         }

--- a/src/main/java/com/pinterest/secor/parser/Partitioner.java
+++ b/src/main/java/com/pinterest/secor/parser/Partitioner.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.message.Message;
+
+import java.util.List;
+
+/**
+ * The Partitioner knows when to finalize a file folder partition.
+ *
+ * A file folder partition (e.g. dt=2015-07-07) can be finalized when all
+ * messages in that date arrived.  The caller (PartitionFinalizer) will do the
+ * finalization work (e.g. generate _SUCCESS file, perform hive registration)
+ *
+ * The partitioner provide the method to calculate the range of file
+ * folder partitions to be finalized and provide the method to iterate through
+ * the range.
+ *
+ * The caller will first provide a list of last-consumed messages for a given
+ * kafka topic and call #getFinalizedUptoPartitions to get the finalized-up-to
+ * partition and then walk backwards by calling #getPreviousPartitions to
+ * collect all the previous partitions which are ready to be finalized.
+ *
+ * Note that finalize-up-to partition itself is not inclusive in the range of
+ * partitions to be finalized.
+ *
+ * The caller might repeat this loop multiple times when the filesystem partition
+ * is multi-dimentional (e.g. [dt=2015-07-07,hr=05]).  it will loop once for the
+ * hourly folder finalization and another time for the daily folder.
+ *
+ * Note that although we use daily/hourly partition illustrate the use of
+ * partitioner, it is be no means the partitioner can only work with timestamp
+ * based partitioning, it should also be able to work with offset based
+ * partitioning as long as we establish an iterating order within those
+ * partitions.
+ *
+ * @author Henry Cai (hcai@pinterest.com)
+ */
+public interface Partitioner {
+    /**
+     * Calculates the partition to finalize-up-to from a list of last-consumed
+     * messages and a list of last-enqueued messages.
+     *
+     * For each kafka topic/partition for a given topic, the caller will provide
+     * two messages:
+     *     * lastMessage: the last message at the tail of the kafka queue
+     *     * committedMessage: the message secor consumed and committed
+     * And then iterate over all the kafka topic partitions for the given topic,
+     * the caller will gather the above two messages into two lists.
+     *
+     * The Partitioner will compare the messages from all kafka partitions to
+     * see which one is the earliest to finalize up to.  The partitioner will
+     * normally use the timestamp from the committedMessage to decide
+     * the finalize time.  But for some slow topics where there is no new
+     * messages coming for a while (i.e. lastMessage == committedMessage),
+     * the partitioner can use the current time as the finalize time.
+     *
+     * Note that the up-to partition itself is not inclusive in the range to be
+     * finalized.  For example, when the last message is in 2015-07-07,
+     * 7/7 itself is not complete yet.
+     *
+     * Note also that the partitioner might want to adjust down the finalize
+     * time to allow a safety lag for late arrival messages.  e.g. adding one
+     * extra hour lag
+     *
+     * @param lastMessages  the last message at the tail of the queue
+     * @param committedMessages  the message secor consumed and committed
+     *
+     * @return  a String array to represent a file folder partition to finalize up to
+     */
+    String[] getFinalizedUptoPartitions(List<Message> lastMessages,
+                                        List<Message> committedMessages) throws Exception;
+
+    /**
+     * Get the previous partition out of the incoming partition.
+     * E.g. for ["dt=2015-07-07","hr=05"], it will return ["dt=2015-07-07","hr=04"]
+     *
+     * @param partition
+     * @return
+     */
+    String[] getPreviousPartitions(String[] partition) throws Exception;
+}

--- a/src/main/java/com/pinterest/secor/parser/Partitioner.java
+++ b/src/main/java/com/pinterest/secor/parser/Partitioner.java
@@ -90,6 +90,13 @@ public interface Partitioner {
      * Get the previous partition out of the incoming partition.
      * E.g. for ["dt=2015-07-07","hr=05"], it will return ["dt=2015-07-07","hr=04"]
      *
+     * Note that the implementation might return the previous sequence in daily/mixed forms, e.g.
+     * [dt=2015-07-07, hr=01]
+     * [dt=2015-07-07, hr=00]
+     * [dt=2015-07-07]        <-- dt folder in between
+     * [dt=2015-07-06, hr=23]
+     * [dt=2015-07-07, hr=22]
+     *
      * @param partition
      * @return
      */

--- a/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
@@ -25,12 +25,17 @@ import java.util.TimeZone;
 
 public abstract class TimestampedMessageParser extends MessageParser {
 
-    private SimpleDateFormat mFormatter;
+    private final SimpleDateFormat dtFormatter;
+    private final SimpleDateFormat hrFormatter;
+    private final boolean usingHourly;
 
     public TimestampedMessageParser(SecorConfig config) {
         super(config);
-        mFormatter = new SimpleDateFormat("yyyy-MM-dd");
-        mFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        dtFormatter = new SimpleDateFormat("yyyy-MM-dd");
+        dtFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        hrFormatter = new SimpleDateFormat("HH");
+        hrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        usingHourly = config.getMessageTimestampUsingHour();
     }
 
     public abstract long extractTimestampMillis(final Message message) throws Exception;
@@ -54,7 +59,12 @@ public abstract class TimestampedMessageParser extends MessageParser {
         // Date constructor takes milliseconds since epoch.
         long timestampMillis = extractTimestampMillis(message);
         Date date = new Date(timestampMillis);
-        String result[] = {"dt=" + mFormatter.format(date)};
-        return result;
+        String dt = "dt=" + dtFormatter.format(date);
+        String hr = "hr=" + hrFormatter.format(date);
+        if (usingHourly) {
+          return new String[]{dt, hr};
+        } else {
+          return new String[]{dt};
+        }
     }
 }

--- a/src/main/java/com/pinterest/secor/tools/TestLogMessageProducer.java
+++ b/src/main/java/com/pinterest/secor/tools/TestLogMessageProducer.java
@@ -40,16 +40,25 @@ public class TestLogMessageProducer extends Thread {
     private final String mTopic;
     private final int mNumMessages;
     private final String mType;
+    private final String mMetadataBrokerList;
+    private final int mTimeshift;
 
-    public TestLogMessageProducer(String topic, int numMessages, String type) {
+    public TestLogMessageProducer(String topic, int numMessages, String type,
+                                  String metadataBrokerList, int timeshift) {
         mTopic = topic;
         mNumMessages = numMessages;
         mType = type;
+        mMetadataBrokerList = metadataBrokerList;
+        mTimeshift = timeshift;
     }
 
     public void run() {
         Properties properties = new Properties();
-        properties.put("metadata.broker.list", "localhost:9092");
+        if (mMetadataBrokerList == null || mMetadataBrokerList.isEmpty()) {
+            properties.put("metadata.broker.list", "localhost:9092");
+        } else {
+            properties.put("metadata.broker.list", mMetadataBrokerList);
+        }
         properties.put("partitioner.class", "com.pinterest.secor.tools.RandomPartitioner");
         properties.put("serializer.class", "kafka.serializer.DefaultEncoder");
         properties.put("key.serializer.class", "kafka.serializer.StringEncoder");
@@ -69,7 +78,8 @@ public class TestLogMessageProducer extends Thread {
 
         TSerializer serializer = new TSerializer(protocol);
         for (int i = 0; i < mNumMessages; ++i) {
-            TestMessage testMessage = new TestMessage(System.currentTimeMillis() * 1000000L + i,
+            long time = (System.currentTimeMillis() - mTimeshift * 1000L) * 1000000L + i;
+            TestMessage testMessage = new TestMessage(time,
                                                       "some_value_" + i);
             if (i % 2 == 0) {
                 testMessage.setEnumField(TestEnum.SOME_VALUE);

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -199,6 +199,7 @@ public class Uploader {
     private void checkTopicPartition(TopicPartition topicPartition) throws Exception {
         final long size = mFileRegistry.getSize(topicPartition);
         final long modificationAgeSec = mFileRegistry.getModificationAgeSec(topicPartition);
+        LOG.debug("size: " + size + " modificationAge: " + modificationAgeSec);
         if (size >= mConfig.getMaxFileSizeBytes() ||
                 modificationAgeSec >= mConfig.getMaxFileAgeSeconds()) {
             long newOffsetCount = mZookeeperConnector.getCommittedOffsetCount(topicPartition);
@@ -206,6 +207,7 @@ public class Uploader {
                     newOffsetCount);
             long lastSeenOffset = mOffsetTracker.getLastSeenOffset(topicPartition);
             if (oldOffsetCount == newOffsetCount) {
+                LOG.debug("Uploading for: " + topicPartition);
                 uploadFiles(topicPartition);
             } else if (newOffsetCount > lastSeenOffset) {  // && oldOffset < newOffset
                 LOG.debug("last seen offset {} is lower than committed offset count {}. Deleting files in topic {} partition {}",

--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -38,7 +38,7 @@ PARENT_DIR=/tmp/secor_dev
 LOGS_DIR=${PARENT_DIR}/logs
 BUCKET=${SECOR_BUCKET:-test-bucket}
 S3_LOGS_DIR=s3://${BUCKET}/secor_dev
-MESSAGES=1000
+MESSAGES=100
 MESSAGE_TYPE=binary
 # For the compression tests to work, set this to the path of the Hadoop native libs.
 HADOOP_NATIVE_LIB_PATH=lib
@@ -46,13 +46,19 @@ HADOOP_NATIVE_LIB_PATH=lib
 ADDITIONAL_OPTS=
 
 # various reader writer options to be used for testing
-declare -A READER_WRITERS
-READER_WRITERS[json]=com.pinterest.secor.io.impl.DelimitedTextFileReaderWriterFactory
-READER_WRITERS[binary]=com.pinterest.secor.io.impl.SequenceFileReaderWriterFactory
+#
+# However older bash (ver <= 3) does not support associative array, falls back
+# to use two arrays
+# declare -A READER_WRITERS
+#
+declare -a READER_WRITER_KEYS
+READER_WRITER_KEYS=(json binary)
+declare -a READER_WRITERS
+READER_WRITERS=(com.pinterest.secor.io.impl.DelimitedTextFileReaderWriterFactory com.pinterest.secor.io.impl.SequenceFileReaderWriterFactory)
 
 # The minimum wait time is one minute plus delta.  Secor is configured to upload files older than
 # one minute and we need to make sure that everything ends up on s3 before starting verification.
-WAIT_TIME=${SECOR_WAIT_TIME:-120}
+WAIT_TIME=${SECOR_WAIT_TIME:-30}
 BASE_DIR=$(dirname $0)
 CONF_DIR=${BASE_DIR}/..
 
@@ -73,7 +79,7 @@ check_for_native_libs() {
 
 recreate_dirs() {
     run_command "rm -r -f ${PARENT_DIR}"
-    if [ -n ${SECOR_LOCAL_S3} ]; then
+    if [ -n "${SECOR_LOCAL_S3}" ]; then
         run_command "s3cmd -c ${CONF_DIR}/test.s3cfg ls ${S3_LOGS_DIR} | awk '{ print \$4 }' | xargs -L 1 s3cmd -c ${CONF_DIR}/test.s3cfg del"
     else
         run_command "s3cmd del --recursive ${S3_LOGS_DIR}"
@@ -85,7 +91,7 @@ recreate_dirs() {
 }
 
 start_s3() {
-    if [ -n ${SECOR_LOCAL_S3} ]; then
+    if [ -n "${SECOR_LOCAL_S3}" ]; then
         if command -v fakes3 > /dev/null 2>&1; then
             run_command "fakes3 --root=/tmp/fakes3 --port=5000 --hostname=localhost > /tmp/fakes3.log 2>&1 &"
             sleep 2
@@ -97,7 +103,7 @@ start_s3() {
 }
 
 stop_s3() {
-    if [ -n ${SECOR_LOCAL_S3} ]; then
+    if [ -n "${SECOR_LOCAL_S3}" ]; then
         run_command "pkill -9 'fakes3' > /dev/null 2>&1 || true"
         run_command "rm -r -f /tmp/fakes3"
     fi
@@ -137,23 +143,46 @@ stop_secor() {
     run_command "pkill -f 'com.pinterest.secor.main.ConsumerMain' || true"
 }
 
+run_finalizer() {
+    run_command "${JAVA} -server -ea -Dlog4j.configuration=log4j.dev.properties \
+        -Dconfig=secor.test.partition.properties ${ADDITIONAL_OPTS} -cp secor-0.1-SNAPSHOT.jar:lib/* \
+        com.pinterest.secor.main.PartitionFinalizerMain > ${LOGS_DIR}/finalizer.log 2>&1 "
+
+    EXIT_CODE=$?
+    if [ ${EXIT_CODE} -ne 0 ]; then
+        echo -e "\e[1;41;97mFinalizer FAILED\e[0m"
+        echo "See log ${LOGS_DIR}/finalizer.log for more details"
+        exit ${EXIT_CODE}
+    fi
+}
+
 create_topic() {
     run_command "${BASE_DIR}/run_kafka_class.sh kafka.admin.TopicCommand --create --zookeeper \
         localhost:2181 --replication-factor 1 --partitions 2 --topic test > \
         ${LOGS_DIR}/create_topic.log 2>&1"
 }
 
+# post messages
+# $1 number of messages
+# $2 timeshift in seconds
 post_messages() {
     run_command "${JAVA} -server -ea -Dlog4j.configuration=log4j.dev.properties \
-        -Dconfig=secor.test.backup.properties -cp ${CLASSPATH} \
-        com.pinterest.secor.main.TestLogMessageProducerMain -t test -m $1 -p 1 -type ${MESSAGE_TYPE} > \
+        -Dconfig=secor.test.backup.properties -cp secor-0.1-SNAPSHOT.jar:lib/* \
+        com.pinterest.secor.main.TestLogMessageProducerMain -t test -m $1 -p 1 -type ${MESSAGE_TYPE} -timeshift $2 > \
         ${LOGS_DIR}/test_log_message_producer.log 2>&1"
 }
 
+# verify the messages
+# $1: number of messages
+# $2: number of _SUCCESS files
 verify() {
+    echo "Verifying $1 $2"
+
     RUNMODE_0="backup"
     if [ "${MESSAGE_TYPE}" = "binary" ]; then
       RUNMODE_1="partition"
+    else
+       RUNMODE_1="backup"
     fi
     for RUNMODE in ${RUNMODE_0} ${RUNMODE_1}; do
       run_command "${JAVA} -server -ea -Dlog4j.configuration=log4j.dev.properties \
@@ -168,6 +197,21 @@ verify() {
         stop_all
         stop_s3
         exit ${VERIFICATION_EXIT_CODE}
+      fi
+
+      # Verify SUCCESS file
+      if [ -n "${SECOR_LOCAL_S3}" ]; then
+          run_command "s3cmd ls -c ${CONF_DIR}/test.s3cfg -r ${S3_LOGS_DIR} | gr
+ep _SUCCESS | wc -l > /tmp/secor_tests_output.txt"
+      else
+          run_command "s3cmd ls -r ${S3_LOGS_DIR} | grep _SUCCESS | wc -l > /tmp/secor_tests_output.txt"
+      fi
+      count=$(</tmp/secor_tests_output.txt)
+      count="${count//[[:space:]]/}"
+      echo "Success file count: $count"
+      if [ "$count" != "$2" ]; then
+        echo -e "\e[1;41;97m_SUCCESS files not as expected: $2 \e[0m"
+        exit 1
       fi
     done
 }
@@ -214,31 +258,100 @@ initialize() {
 
 # Post some messages and verify that they are correctly processed.
 post_and_verify_test() {
+    echo "********************************************************"
     echo "running post_and_verify_test"
     initialize
 
     start_secor
     sleep 3
-    post_messages ${MESSAGES}
+    post_messages ${MESSAGES} 0
     echo "Waiting ${WAIT_TIME} sec for Secor to upload logs to s3"
     sleep ${WAIT_TIME}
-    verify ${MESSAGES}
+    verify ${MESSAGES} 0
 
     stop_all
     echo -e "\e[1;42;97mpost_and_verify_test succeeded\e[0m"
 }
 
+# Post some messages and run the finalizer, count # of messages and success file
+# $1: hr or dt, decides whether it's hourly or daily folder finalization
+# $2: number of messages 
+post_and_finalizer_verify_test() {
+    echo "********************************************************"
+    date=$(date -u +'%Y-%m-%d %H:%M:%S')
+    read Y M D h m s <<< ${date//[-: ]/ }
+    if [ $m -ge 55 ]; then
+        # we have to know the number of hr/dt folders to be created
+        echo "It's too close to the hour mark: $m, skip the test"
+        return
+    fi
+    if [ $h -le 1 ]; then
+        # This will make the timeshift pass the day boundary
+        echo "It's too close to the day mark: $h, skip the test"
+        return
+    fi
+
+    if [ $1 = "hr" ]; then
+        ADDITIONAL_OPTS="-Dsecor.file.reader.writer.factory=${READER_WRITERS[${num}]} -Dmessage.timestamp.using.hour=true"
+        # for hr folder, the finalizer lag is 1 hour
+        TIMESHIFT=$((3600+1200))
+        if [ $2 -ne 0 ]; then
+            # should be 2 success files, one for hr folder, 
+            # one for yesterday's dt folder
+            FILES=2
+        else
+            # should be 0 success files
+            FILES=0
+        fi
+    else
+        ADDITIONAL_OPTS="-Dsecor.file.reader.writer.factory=${READER_WRITERS[${num}]}"
+        # for dt folder, the finalizer lag is 1 day + 1 hour
+        TIMESHIFT=$((86400+3600+1200))
+        if [ $2 -ne 0 ]; then
+            # should be 1 success files
+            FILES=1
+        else
+            # should be 0 success files
+            FILES=0
+        fi
+    fi
+    echo "Expected success file: $FILES"
+
+    echo "running post_and_finalizer_verify_test $1 $2"
+    initialize
+
+    start_secor
+    sleep 3
+    
+    # post some older messages
+    post_messages $2 ${TIMESHIFT}
+    # post some newer messages
+    post_messages ${MESSAGES} 0
+
+    echo "Waiting ${WAIT_TIME} sec for Secor to upload logs to s3"
+    sleep ${WAIT_TIME}
+
+    echo "start finalizer"
+    run_finalizer
+
+    verify $((0+$2+${MESSAGES})) ${FILES}
+
+    stop_all
+    echo -e "\e[1;42;97mpost_and_finalizer_verify_test succeeded\e[0m"
+}
+
 # Adjust offsets so that Secor consumes only half of the messages.
 start_from_non_zero_offset_test() {
+    echo "********************************************************"
     echo "running start_from_non_zero_offset_test"
     initialize
 
     set_offsets_in_zookeeper $((${MESSAGES}/4))
-    post_messages ${MESSAGES}
+    post_messages ${MESSAGES} 0
     start_secor
     echo "Waiting ${WAIT_TIME} sec for Secor to upload logs to s3"
     sleep ${WAIT_TIME}
-    verify $((${MESSAGES}/2))
+    verify $((${MESSAGES}/2)) 0
 
     stop_all
     echo -e "\e[1;42;97mstart_from_non_zero_offset_test succeeded\e[0m"
@@ -247,19 +360,20 @@ start_from_non_zero_offset_test() {
 # Set offset after consumers processed some of the messages.  This scenario simulates a
 # re-balancing event and potential topic reassignment triggering the need to trim local log files.
 move_offset_back_test() {
+    echo "********************************************************"
     echo "running move_offset_back_test"
     initialize
 
     start_secor
     sleep 3
-    post_messages $((${MESSAGES}/10))
+    post_messages $((${MESSAGES}/10)) 0
     set_offsets_in_zookeeper 2
-    post_messages $((${MESSAGES}*9/10))
+    post_messages $((${MESSAGES}*9/10)) 0
 
     echo "Waiting ${WAIT_TIME} sec for Secor to upload logs to s3"
     sleep ${WAIT_TIME}
     # 4 because we skipped 2 messages per topic partition and there are 2 partitions per topic.
-    verify $((${MESSAGES}-4))
+    verify $((${MESSAGES}-4)) 0
 
     stop_all
     echo -e "\e[1;42;97mmove_offset_back_test succeeded\e[0m"
@@ -267,6 +381,7 @@ move_offset_back_test() {
 
 # Post some messages and verify that they are correctly processed and compressed.
 post_and_verify_compressed_test() {
+    echo "********************************************************"
     echo "running post_and_verify_compressed_test"
     initialize
 
@@ -275,10 +390,10 @@ post_and_verify_compressed_test() {
         -Djava.library.path=$HADOOP_NATIVE_LIB_PATH"
     start_secor
     sleep 3
-    post_messages ${MESSAGES}
+    post_messages ${MESSAGES} 0
     echo "Waiting ${WAIT_TIME} sec for Secor to upload logs to s3"
     sleep ${WAIT_TIME}
-    verify ${MESSAGES}
+    verify ${MESSAGES} 0
 
     stop_all
     echo -e "\e[1;42;97mpost_and_verify_compressed_test succeeded\e[0m"
@@ -287,19 +402,33 @@ post_and_verify_compressed_test() {
 check_for_native_libs
 start_s3
 
-for key in ${!READER_WRITERS[@]}; do
-   MESSAGE_TYPE=${key}
-   ADDITIONAL_OPTS=-Dsecor.file.reader.writer.factory=${READER_WRITERS[${key}]}
-   echo "Running tests for Message Type: ${MESSAGE_TYPE} and ReaderWriter: ${READER_WRITERS[${key}]}"
+# Testing finalizer in partition mode
+num=1
+MESSAGE_TYPE=${READER_WRITER_KEYS[${num}]}
+echo "********************************************************"
+echo "Running hourly finalizer tests for Message Type: ${MESSAGE_TYPE} and ReaderWriter: ${READER_WRITERS[${num}]}"
+post_and_finalizer_verify_test hr 0
+post_and_finalizer_verify_test hr 100
+
+echo "********************************************************"
+echo "Running daily finalizer tests for Message Type: ${MESSAGE_TYPE} and ReaderWriter: ${READER_WRITERS[${num}]}"
+post_and_finalizer_verify_test dt 0
+post_and_finalizer_verify_test dt 100
+
+for num in 0 ${#READER_WRITERS[@]}-1; do
+   MESSAGE_TYPE=${READER_WRITER_KEYS[${num}]}
+   ADDITIONAL_OPTS=-Dsecor.file.reader.writer.factory=${READER_WRITERS[${num}]}
+   echo "********************************************************"
+   echo "Running tests for Message Type: ${MESSAGE_TYPE} and ReaderWriter: ${READER_WRITERS[${num}]}"
    post_and_verify_test
    start_from_non_zero_offset_test
    move_offset_back_test
-   if [ ${key} = "json" ]; then
+   if [ ${MESSAGE_TYPE} = "json" ]; then
        post_and_verify_compressed_test
    elif [ -z ${SKIP_COMPRESSED_BINARY} ]; then
        post_and_verify_compressed_test
    else
-       echo "Skipping compressed tests for ${key}"
+       echo "Skipping compressed tests for ${MESSAGE_TYPE}"
    fi
 done
 

--- a/src/test/java/com/pinterest/secor/parser/JsonMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/JsonMessageParserTest.java
@@ -18,11 +18,16 @@ package com.pinterest.secor.parser;
 
 import com.pinterest.secor.common.*;
 import com.pinterest.secor.message.Message;
+
+import java.util.Arrays;
+import java.util.List;
 import junit.framework.TestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
 
 @RunWith(PowerMockRunner.class)
 public class JsonMessageParserTest extends TestCase {
@@ -39,15 +44,15 @@ public class JsonMessageParserTest extends TestCase {
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
 
         byte messageWithSecondsTimestamp[] =
-                "{\"timestamp\":\"1405970352\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
+                "{\"timestamp\":\"1405911096\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
         mMessageWithSecondsTimestamp = new Message("test", 0, 0, messageWithSecondsTimestamp);
 
         byte messageWithMillisTimestamp[] =
-                "{\"timestamp\":\"1405970352123\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
+                "{\"timestamp\":\"1405911096123\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
         mMessageWithMillisTimestamp = new Message("test", 0, 0, messageWithMillisTimestamp);
 
         byte messageWithMillisFloatTimestamp[] =
-                "{\"timestamp\":\"1405970352123.0\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
+                "{\"timestamp\":\"1405911096123.0\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
         mMessageWithMillisFloatTimestamp = new Message("test", 0, 0, messageWithMillisFloatTimestamp);
 
         byte messageWithoutTimestamp[] =
@@ -59,9 +64,9 @@ public class JsonMessageParserTest extends TestCase {
     public void testExtractTimestampMillis() throws Exception {
         JsonMessageParser jsonMessageParser = new JsonMessageParser(mConfig);
 
-        assertEquals(1405970352000l, jsonMessageParser.extractTimestampMillis(mMessageWithSecondsTimestamp));
-        assertEquals(1405970352123l, jsonMessageParser.extractTimestampMillis(mMessageWithMillisTimestamp));
-        assertEquals(1405970352123l, jsonMessageParser.extractTimestampMillis(mMessageWithMillisFloatTimestamp));
+        assertEquals(1405911096000l, jsonMessageParser.extractTimestampMillis(mMessageWithSecondsTimestamp));
+        assertEquals(1405911096123l, jsonMessageParser.extractTimestampMillis(mMessageWithMillisTimestamp));
+        assertEquals(1405911096123l, jsonMessageParser.extractTimestampMillis(mMessageWithMillisFloatTimestamp));
 
         // Return 0 if there's no timestamp, for any reason.
 
@@ -101,11 +106,11 @@ public class JsonMessageParserTest extends TestCase {
 
     @Test
     public void testExtractHourlyPartitions() throws Exception {
-        Mockito.when(mConfig.getMessageTimestampUsingHour()).thenReturn(true);
+        Mockito.when(TimestampedMessageParser.usingHourly(mConfig)).thenReturn(true);
         JsonMessageParser jsonMessageParser = new JsonMessageParser(mConfig);
 
         String expectedDtPartition = "dt=2014-07-21";
-        String expectedHrPartition = "hr=19";
+        String expectedHrPartition = "hr=02";
 
         String resultSeconds[] = jsonMessageParser.extractPartitions(mMessageWithSecondsTimestamp);
         assertEquals(2, resultSeconds.length);
@@ -116,6 +121,86 @@ public class JsonMessageParserTest extends TestCase {
         assertEquals(2, resultMillis.length);
         assertEquals(expectedDtPartition, resultMillis[0]);
         assertEquals(expectedHrPartition, resultMillis[1]);
+    }
+
+    @Test
+    public void testDailyGetFinalizedUptoPartitions() throws Exception {
+        JsonMessageParser jsonMessageParser = new JsonMessageParser(mConfig);
+
+        List<Message> lastMessages = new ArrayList<Message>();
+        lastMessages.add(mMessageWithSecondsTimestamp);
+        List<Message> committedMessages = new ArrayList<Message>();
+        committedMessages.add(mMessageWithMillisTimestamp);
+        String uptoPartitions[] = jsonMessageParser.getFinalizedUptoPartitions(lastMessages,
+            committedMessages);
+        assertEquals(1, uptoPartitions.length);
+        assertEquals("dt=2014-07-21", uptoPartitions[0]);
+
+        String[] previous = jsonMessageParser.getPreviousPartitions(uptoPartitions);
+        assertEquals(1, previous.length);
+        assertEquals("dt=2014-07-20", previous[0]);
+    }
+
+    @Test
+    public void testHourlyGetFinalizedUptoPartitions() throws Exception {
+        Mockito.when(TimestampedMessageParser.usingHourly(mConfig)).thenReturn(true);
+        JsonMessageParser jsonMessageParser = new JsonMessageParser(mConfig);
+
+        List<Message> lastMessages = new ArrayList<Message>();
+        lastMessages.add(mMessageWithSecondsTimestamp);
+        List<Message> committedMessages = new ArrayList<Message>();
+        committedMessages.add(mMessageWithMillisTimestamp);
+        String uptoPartitions[] = jsonMessageParser.getFinalizedUptoPartitions(lastMessages,
+            committedMessages);
+        assertEquals(2, uptoPartitions.length);
+        assertEquals("dt=2014-07-21", uptoPartitions[0]);
+        assertEquals("hr=01", uptoPartitions[1]);
+
+        String[][] expectedPartitions = new String[][] {
+          new String[]{"dt=2014-07-21", "hr=00"},
+          new String[]{"dt=2014-07-20"},  // there is day partition for previous day
+          new String[]{"dt=2014-07-20", "hr=23"},
+          new String[]{"dt=2014-07-20", "hr=22"},
+          new String[]{"dt=2014-07-20", "hr=21"},
+          new String[]{"dt=2014-07-20", "hr=20"},
+          new String[]{"dt=2014-07-20", "hr=19"},
+          new String[]{"dt=2014-07-20", "hr=18"},
+          new String[]{"dt=2014-07-20", "hr=17"},
+          new String[]{"dt=2014-07-20", "hr=16"},
+          new String[]{"dt=2014-07-20", "hr=15"},
+          new String[]{"dt=2014-07-20", "hr=14"},
+          new String[]{"dt=2014-07-20", "hr=13"},
+          new String[]{"dt=2014-07-20", "hr=12"},
+          new String[]{"dt=2014-07-20", "hr=11"},
+          new String[]{"dt=2014-07-20", "hr=10"},
+          new String[]{"dt=2014-07-20", "hr=09"},
+          new String[]{"dt=2014-07-20", "hr=08"},
+          new String[]{"dt=2014-07-20", "hr=07"},
+          new String[]{"dt=2014-07-20", "hr=06"},
+          new String[]{"dt=2014-07-20", "hr=05"},
+          new String[]{"dt=2014-07-20", "hr=04"},
+          new String[]{"dt=2014-07-20", "hr=03"},
+          new String[]{"dt=2014-07-20", "hr=02"},
+          new String[]{"dt=2014-07-20", "hr=01"},
+          new String[]{"dt=2014-07-20", "hr=00"},
+          new String[]{"dt=2014-07-19"},  // there is day partition for 2nd last day
+          new String[]{"dt=2014-07-19", "hr=23"}
+        };
+
+        String[] partitions = uptoPartitions;
+        List<String[]> partitionsList = new ArrayList<String[]>();
+        for (int i = 0; i < 28; i++ ) {
+            String[] previous = jsonMessageParser.getPreviousPartitions(partitions);
+            partitionsList.add(previous);
+            partitions = previous;
+        }
+
+        assertEquals(partitionsList.size(), expectedPartitions.length);
+        for (int i = 0; i < partitionsList.size(); i++) {
+            List<String> expectedPartition = Arrays.asList(expectedPartitions[i]);
+            List<String> retrievedPartition = Arrays.asList(partitionsList.get(i));
+            assertEquals(expectedPartition, retrievedPartition);
+        }
     }
 
 }

--- a/src/test/java/com/pinterest/secor/parser/JsonMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/JsonMessageParserTest.java
@@ -98,4 +98,24 @@ public class JsonMessageParserTest extends TestCase {
         assertEquals(1, resultMillis.length);
         assertEquals(expectedPartition, resultMillis[0]);
     }
+
+    @Test
+    public void testExtractHourlyPartitions() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampUsingHour()).thenReturn(true);
+        JsonMessageParser jsonMessageParser = new JsonMessageParser(mConfig);
+
+        String expectedDtPartition = "dt=2014-07-21";
+        String expectedHrPartition = "hr=19";
+
+        String resultSeconds[] = jsonMessageParser.extractPartitions(mMessageWithSecondsTimestamp);
+        assertEquals(2, resultSeconds.length);
+        assertEquals(expectedDtPartition, resultSeconds[0]);
+        assertEquals(expectedHrPartition, resultSeconds[1]);
+
+        String resultMillis[] = jsonMessageParser.extractPartitions(mMessageWithMillisTimestamp);
+        assertEquals(2, resultMillis.length);
+        assertEquals(expectedDtPartition, resultMillis[0]);
+        assertEquals(expectedHrPartition, resultMillis[1]);
+    }
+
 }


### PR DESCRIPTION
    Summary:
    - Add the capability of partition the data file in S3 using hourly folder:
       s3://pinlogs/secor_raw_logs/topic1/dt=2015-07-07/hr=05/
      This way, the data file will be on S3 much sooner (hourly vs daily), people can check the result on S3 much sooner and this also opens the door to have an faster hourly data pipeline on Hadoop side as well.
      The hr folder values are from 00-23

    - To trigger the hourly partition and finalization, add the following parameter in your secor config:
        * message.timestamp.using.hour=true
      And change the upload threshold to less than one hour:
        * secor.max.file.age.seconds=3000

    - Change the hive partition registration code to register partition using both dt and hr column (it does require the HIVE table to be created or altered to have both dt and hr as the partition columns)

    - The enhancements are done through the following:
      * Change the TimestampedMessageParser to allow it to extract both the dt and hr from the timestamp field
      * Change the Finalizer to go through both the hr and dt folder to generate the SUCCESS file and do hive registration
        - the dt finalizer lag before finalization was old way: 1 day + 1 hour lag
        - the hr finalizer lag was defined as: 1 hour lag

    - Added more unit test on message parser on hourly behavior
    - Added more E2E tests to cover the partitioner and hourly ingestion

    Test Plan: Added both unit tests and e2e tests, and tested manually for a new topic on S3