### PR TITLE
Simple timestamped message parser for protocol buffers.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>2.6.1</version>
+        </dependency>
+        <dependency>
             <groupId>net.java.dev.jets3t</groupId>
             <artifactId>jets3t</artifactId>
             <version>0.7.1</version>

--- a/src/main/java/com/pinterest/secor/parser/ProtobufMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/ProtobufMessageParser.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import com.google.protobuf.CodedInputStream;
+
+import java.io.IOException;
+
+/**
+ * Basic protocol buffer parser.
+ *
+ * Assumes that the timestamp field is the first field, is required,
+ * and is a uint64. A more advanced parser might support an arbitrary
+ * field number (non-nested to keep things simple) and perhaps
+ * different data types.
+ *
+ * @author Liam Stewart (liam.stewart@gmail.com)
+ */
+public class ProtobufMessageParser extends TimestampedMessageParser {
+    public ProtobufMessageParser(SecorConfig config) {
+        super(config);
+    }
+
+    @Override
+    public long extractTimestampMillis(final Message message) throws IOException {
+        CodedInputStream input = CodedInputStream.newInstance(message.getPayload());
+
+        // Don't really care about the tag, but need to read it to get
+        // to the payload.
+        int tag = input.readTag();
+        return toMillis(input.readUInt64());
+    }
+}

--- a/src/test/java/com/pinterest/secor/parser/ProtobufMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/ProtobufMessageParserTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+import com.google.protobuf.CodedOutputStream;
+
+@RunWith(PowerMockRunner.class)
+public class ProtobufMessageParserTest extends TestCase {
+    private SecorConfig mConfig;
+
+    private Message buildMessage(long timestamp) throws Exception {
+        byte data[] = new byte[16];
+        CodedOutputStream output = CodedOutputStream.newInstance(data);
+        output.writeUInt64(1, timestamp);
+        return new Message("test", 0, 0, data);
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        mConfig = Mockito.mock(SecorConfig.class);
+    }
+
+    @Test
+    public void testExtractTimestampMillis() throws Exception {
+        ProtobufMessageParser parser = new ProtobufMessageParser(mConfig);
+
+        assertEquals(1405970352000l, parser.extractTimestampMillis(buildMessage(1405970352l)));
+        assertEquals(1405970352123l, parser.extractTimestampMillis(buildMessage(1405970352123l)));
+    }
+}


### PR DESCRIPTION
This is similar to the thrift message parser in that it expects the first field to be a uint64 timestamp. Works well enough for us and avoids either having to create a parser that either links in generated protobuf code or uses dynamic messages and descriptors.