### PR TITLE
Support params for schema registry and add optional parsedRecord to KeyValue to allow more context to be passed to writer/reader

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -168,7 +168,7 @@ secor.upload.manager.class=com.pinterest.secor.uploader.HadoopS3UploadManager
 
 # Schema registry URL that can be used by parsers that support or require a schema registry
 # This can be used for formats that require the schema to deserialize, eg Avro
-schema.url=
+schema.registry.url=
 
 # Number of cached schemas the registry should keep local at a time. Defaults to 1000.
-schema.cache.count=
+schema.registry.cache.count=

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -165,3 +165,10 @@ secor.max.message.size.bytes=100000
 # Class that will manage uploads. Default is to use the hadoop
 # interface to S3.
 secor.upload.manager.class=com.pinterest.secor.uploader.HadoopS3UploadManager
+
+# Schema registry URL that can be used by parsers that support or require a schema registry
+# This can be used for formats that require the schema to deserialize, eg Avro
+schema.url=
+
+# Number of cached schemas the registry should keep local at a time. Defaults to 1000.
+schema.cache.count=

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -112,11 +112,11 @@ public class SecorConfig {
     }
 
     public String getSchemaUrl() {
-        return getString("schema.url");
+        return getString("schema.registry.url");
     }
 
     public int getSchemaCacheCount() {
-        return getInt("schema.cache.count", 1000);
+        return getInt("schema.registry.cache.count", 1000);
     }
 
     public int getGeneration() {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -111,6 +111,14 @@ public class SecorConfig {
         return getString("kafka.fetch.wait.max.ms");
     }
 
+    public String getSchemaUrl() {
+        return getString("schema.url");
+    }
+
+    public int getSchemaCacheCount() {
+        return getInt("schema.cache.count", 1000);
+    }
+
     public int getGeneration() {
         return getInt("secor.generation");
     }

--- a/src/main/java/com/pinterest/secor/io/KeyValue.java
+++ b/src/main/java/com/pinterest/secor/io/KeyValue.java
@@ -27,13 +27,21 @@ public class KeyValue {
 	
 	private final long mKey;
 	private final byte[] mValue;
-	
+	private final Object mParsedRecord;
+
 	//constructor
 	public KeyValue(long key, byte[] value) {
 		this.mKey = key;
 		this.mValue = value;
+		this.mParsedRecord = null;
 	}
-	
+
+	public KeyValue(long key, byte[] value, Object parsedRecord) {
+		this.mKey = key;
+		this.mValue = value;
+		this.mParsedRecord = parsedRecord;
+	}
+
 	public long getKey() {
 		return this.mKey;
 	}
@@ -42,4 +50,7 @@ public class KeyValue {
 		return this.mValue;
 	}
 
+	public Object parsedRecord() {
+		return this.mParsedRecord;
+	}
 }

--- a/src/main/java/com/pinterest/secor/message/ParsedMessage.java
+++ b/src/main/java/com/pinterest/secor/message/ParsedMessage.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
  */
 public class ParsedMessage extends Message {
     private String[] mPartitions;
+    private Object mParsedRecord;
 
     @Override
     public String toString() {
@@ -40,7 +41,16 @@ public class ParsedMessage extends Message {
         this.mPartitions = mPartitions;
     }
 
+    public ParsedMessage(String topic, int kafkaPartition, long offset, byte[] payload,
+                         String[] mPartitions, Object parsedRecord) {
+        super(topic, kafkaPartition, offset, payload);
+        this.mPartitions = mPartitions;
+        this.mParsedRecord = parsedRecord;
+    }
+
     public String[] getPartitions() {
         return mPartitions;
     }
+
+    public Object getParsedRecord() { return mParsedRecord; }
 }

--- a/src/main/java/com/pinterest/secor/writer/MessageWriter.java
+++ b/src/main/java/com/pinterest/secor/writer/MessageWriter.java
@@ -88,7 +88,7 @@ public class MessageWriter {
         LogFilePath path = new LogFilePath(mLocalPrefix, mGeneration, offset, message,
         		mFileExtension);
         FileWriter writer = mFileRegistry.getOrCreateWriter(path, mCodec);
-        writer.write(new KeyValue(message.getOffset(), message.getPayload()));
+        writer.write(new KeyValue(message.getOffset(), message.getPayload(), message.getParsedRecord()));
         LOG.debug("appended message {} to file {}.  File length {}",
                   message, path, writer.getLength());
     }


### PR DESCRIPTION
This PR isn't complete, but before I went further wanted to make sure maintainers were on board with the change and open things up to discussion. 

It pushes a schema registry into both the writer and the parser to enable messages to be parsed coming out of Kafka and written out with the proper avro object container format. 

Things that are left to do before I'd expect this to be mergeable:
- Tests, duh
- Support compression
- Port over avro message parser to Java and include it: 
  https://gist.github.com/ppearcy/d6aee9be77cd9aa362a3

There's also the potential to plugin other schema registries, similar as other components. I'm not quite sure if that makes sense yet, unless you know of other registries out there you know you'd want to support. 

These changes also open up the door for Secor to read avro out of Kafka and generate either parquet (via AvroSchemaConverter) or to orc file (via  AvroObjectInspectorGenerator). 
