### PR TITLE
Add support to enable deploy/publish through SonaType to maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.pinterest.secor</groupId>
+    <groupId>com.pinterest</groupId>
     <artifactId>secor</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
+    <name>secor</name>
     <description>Kafka to s3 logs exporter</description>
+    <url>https://github.com/pinterest/secor</url>
 
     <licenses>
         <license>
@@ -19,12 +21,48 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <id>pgarbacki</id>
+            <name>Pawel Garbacki</name>
+        </developer>
+        <developer>
+            <id>yuyang</id>
+            <name>Yu Yang</name>
+        </developer>
+        <developer>
+            <id>ramki</id>
+            <name>Ramki Venkatachalam</name>
+        </developer>
+        <developer>
+            <id>hcai</id>
+            <name>Henry Cai</name>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>https://github.com/pinterest/secor.git</connection>
+        <developerConnection>https://github.com/pinterest/secor.git</developerConnection>
+        <url>https://github.com/pinterest/secor</url>
+    </scm>
+
     <properties>
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <distributionManagement>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
 
     <repositories>
         <repository>
@@ -326,6 +364,67 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.3</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                              </execution>
+                          </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                              </execution>
+                          </executions>
+                    </plugin>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-gpg-plugin</artifactId>
+                      <version>1.5</version>
+                      <executions>
+                          <execution>
+                              <id>sign-artifacts</id>
+                              <phase>verify</phase>
+                              <goals>
+                                  <goal>sign</goal>
+                              </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Added all the required change to pom to allow build publishing to maven central through SonaType.org.

Most of the changes are following examples in:
http://central.sonatype.org/pages/ossrh-guide.html

The first version is published to maven under (including both sources and javadoc jars):
https://repo1.maven.org/maven2/com/pinterest/secor/0.1

Since ver 0.1 is published, our current SNAPSHOT build will be upgraded to 0.2-SNAPSHOT

To publish the snapshot build (you need to have SonaType account and GnuPGP signing tools configured):
    # make sure the version in pom.xml ends with SNAPSHOT
    mvn clean deploy
    # the artifacts will stay in Sonatype repo (not going into maven central)

To publish a release build
    # make sure the version in pom.xml not ends with SNAPSHOT
    mvn clean deploy -P release
    # the artifacts are pushed all the way through to maven central
    # when the release build is published to maven central, make sure the version in pom.xml is upgraded to next-version-SNAPSHOT to reflect we are not building snapshot for next version until it's ready to be version released.