### PR TITLE
Remove s3a testing.

### DIFF
--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -54,7 +54,7 @@ READER_WRITERS[json]=com.pinterest.secor.io.impl.DelimitedTextFileReaderWriterFa
 READER_WRITERS[binary]=com.pinterest.secor.io.impl.SequenceFileReaderWriterFactory
 
 # Hadoop supports multiple implementations of the s3 filesytem
-S3_FILESYSTEMS=${S3_FILESYSTEMS:-s3a s3n}
+S3_FILESYSTEMS=${S3_FILESYSTEMS:-s3n}
 
 # The minimum wait time is one minute plus delta.  Secor is configured to upload files older than
 # one minute and we need to make sure that everything ends up on s3 before starting verification.


### PR DESCRIPTION
So that travis-ci testing does not run over 50 minutes, remove s3a testing.