### PR TITLE
Google cloud storage upload w/ backoff retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Secor is distributed under [Apache License, Version 2.0](http://www.apache.org/l
   * [Strava](https://www.strava.com)
   * [TiVo](https://www.tivo.com)
   * [Yelp](http://www.yelp.com)
+  * [VarageSale](http://www.varagesale.com)
 
 ## Help
 

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -272,6 +272,14 @@ public class SecorConfig {
         return getString("secor.gs.path");
     }
 
+    public int getGsConnectTimeoutInMs() {
+        return getInt("secor.gs.connect.timeout.ms", 3 * 60000);
+    }
+
+    public int getGsReadTimeoutInMs() {
+        return getInt("secor.gs.read.timeout.ms", 3 * 60000);
+    }
+
     public boolean getBoolean(String name, boolean defaultValue) {
         return mProperties.getBoolean(name, defaultValue);
     }


### PR DESCRIPTION
I finally made the Google cloud storage upload a bit more resilient by adding Backoff retries on error. (The direct upload solution wasn't up to par finally)

This improved the upload success rate by quite a large margin in our case.