### PR TITLE
Allow setting a custom file extension to files.

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -159,6 +159,10 @@ message.timestamp.input.pattern=
 # 'org.apache.hadoop.io.compress.GzipCodec'.
 secor.compression.codec=
 
+# To set a custom file extension set this to a valid file suffix, such as
+# '.gz', '.part', etc.
+secor.file.extension=
+
 # The secor file reader/writer used to read/write the data, by default we write sequence files
 secor.file.reader.writer.factory=com.pinterest.secor.io.impl.SequenceFileReaderWriterFactory
 

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -184,6 +184,10 @@ public class SecorConfig {
         return getInt("secor.local.log.delete.age.hours");
     }
 
+    public String getFileExtension() {
+        return getString("secor.file.extension");
+    }
+
     public int getOstrichPort() {
         return getInt("ostrich.port");
     }

--- a/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
+++ b/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
@@ -54,7 +54,9 @@ public class PartitionFinalizer {
         mMessageParser = (TimestampedMessageParser) ReflectionUtil.createMessageParser(
           mConfig.getMessageParserClass(), mConfig);
         mQuboleClient = new QuboleClient(mConfig);
-        if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
+        if (mConfig.getFileExtension() != null) {
+            mFileExtension = mConfig.getFileExtension();
+        } else if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
             CompressionCodec codec = CompressionUtil.createCompressionCodec(mConfig.getCompressionCodec());
             mFileExtension = codec.getDefaultExtension();
         } else {


### PR DESCRIPTION
Set the config param `secor.file.extension` to customize the log file
extension.

eg: secor.file.extension=.bin