### PR TITLE
Adding support for RegEx based parsing.

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/RegexMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/RegexMessageParser.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * RegexMessageParser extracts timestamp field (specified by 'message.timestamp.input.pattern')
+ * The pattern specifies the regular exp to extract the timestamp field from a free-text line.
+ *
+ *  * @author Henry Cai (hcai@pinterest.com)
+ */
+public class RegexMessageParser extends TimestampedMessageParser {
+    private static final Logger LOG = LoggerFactory.getLogger(RegexMessageParser.class);
+
+    private final Pattern mTsPattern;
+
+    public RegexMessageParser(SecorConfig config) {
+        super(config);
+        String patStr = config.getMessageTimestampInputPattern();
+        LOG.info("timestamp pattern: {}", patStr);
+        mTsPattern = Pattern.compile(patStr);
+    }
+
+    @Override
+    public long extractTimestampMillis(final Message message) {
+        String line = new String(message.getPayload());
+        Matcher m = mTsPattern.matcher(line);
+        if (m.find()) {
+            String tsValue = m.group(1);
+            if (tsValue != null) {
+                return toMillis(Long.parseLong(tsValue));
+            }
+        }
+        throw new NumberFormatException("Cannot find timestamp field in: " + line);
+    }
+
+}

--- a/src/test/java/com/pinterest/secor/parser/RegexMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/RegexMessageParserTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.*;
+import com.pinterest.secor.message.Message;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+public class RegexMessageParserTest extends TestCase {
+
+    private SecorConfig mConfig;
+    private Message mMessageWithMillisTimestamp;
+    private Message mMessageWithWrongFormatTimestamp;
+
+    @Override
+    public void setUp() throws Exception {
+        mConfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("^[^ ]+ [^ ]+ ([^ ]+) .*$");
+
+        byte messageWithMillisTimestamp[] =
+            "?24.140.88.218 2015/09/22T22:19:00+0000 1442960340 GET http://api.com/test/?id=123 HTTP/1.1 s200 1017 0.384213448 pass - r685206763364 91ea566f - \"for iOS/5.4.2 (iPhone; 9.0)\"".getBytes("UTF-8");
+        mMessageWithMillisTimestamp = new Message("test", 0, 0, messageWithMillisTimestamp);
+
+      byte messageWithWrongFormatTimestamp[] =
+          "?24.140.88.218 2015/09/22T22:19:00+0000 A1442960340 GET http://api.com/test/?id=123 HTTP/1.1 s200 1017 0.384213448 pass - r685206763364 91ea566f - \"for iOS/5.4.2 (iPhone; 9.0)\"".getBytes("UTF-8");
+      mMessageWithWrongFormatTimestamp = new Message("test", 0, 0, messageWithWrongFormatTimestamp);
+
+    }
+
+    @Test
+    public void testExtractTimestampMillis() throws Exception {
+        RegexMessageParser regexMessageParser = new RegexMessageParser(mConfig);
+
+        assertEquals(1442960340000l, regexMessageParser.extractTimestampMillis(mMessageWithMillisTimestamp));
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testExtractTimestampMillisEmpty() throws Exception {
+        RegexMessageParser regexMessageParser = new RegexMessageParser(mConfig);
+        byte emptyBytes2[] = "".getBytes();
+        regexMessageParser.extractTimestampMillis(new Message("test", 0, 0, emptyBytes2));
+    }
+
+    @Test(expected=NumberFormatException.class)
+    public void testExtractTimestampMillisException1() throws Exception {
+        RegexMessageParser regexMessageParser = new RegexMessageParser(mConfig);
+       regexMessageParser.extractTimestampMillis(mMessageWithWrongFormatTimestamp);
+    }
+
+}


### PR DESCRIPTION
We have cases where the kafka message is a plain text and people use regex to extract the fields (e.g. timestamp).

Add support to allow people specify RegEx based parser, "message.timestamp.input.pattern" is used to specify a regex pattern to extract the timestamp, e.g.:

    ^[^ ]+ [^ ]+ ([^ ]+) .*$

The first group in the regex indicates the timestamp field