### PR TITLE
Change the rebalance partition assignment from roundrobin back to range

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -73,6 +73,12 @@ secor.zookeeper.path=/
 # Impacts how frequently the upload logic is triggered if no messages are delivered.
 kafka.consumer.timeout.ms=10000
 
+# Choose between range and roundrobin partition assignment strategy for kafka 
+# high level consumers. Check PartitionAssignor.scala in kafa 821 module for 
+# the differences between the two.  
+# In kafka 811, only range strategy is supported.
+kafka.partition.assignment.strategy=range
+
 # Max number of retries during rebalance.
 kafka.rebalance.max.retries=
 

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -87,6 +87,10 @@ public class SecorConfig {
         return getInt("kafka.consumer.timeout.ms");
     }
 
+    public String getPartitionAssignmentStrategy() {
+        return getString("kafka.partition.assignment.strategy");
+    }
+
     public String getRebalanceMaxRetries() {
         return getString("kafka.rebalance.max.retries");
     }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -115,7 +115,7 @@ public class MessageReader {
         props.put("auto.offset.reset", "smallest");
         props.put("consumer.timeout.ms", Integer.toString(mConfig.getConsumerTimeoutMs()));
         props.put("consumer.id", IdUtil.getConsumerId());
-        props.put("partition.assignment.strategy", "roundrobin");
+        props.put("partition.assignment.strategy", mConfig.getPartitionAssignmentStrategy());
         if (mConfig.getRebalanceMaxRetries() != null &&
             !mConfig.getRebalanceMaxRetries().isEmpty()) {
             props.put("rebalance.max.retries", mConfig.getRebalanceMaxRetries());


### PR DESCRIPTION
When secor was packaged with kafka811, the partition assignment between consumers threads is range assignment (this is the only assignment supported in 811).

When yyejun upgrades secor with kafka821, https://github.com/pinterest/secor/commit/42ab0a61ea1a4353b614cb2ff37638fc1893d658
 he changed the partition assignment from 'range' to 'roundrobin'), this has two issues on us:
1. when we migrate secor's version, we cannot do rolling upgrade anymore since the partition assignment was done differently between the old and new nodes;
2. I feel the range assignment is probably better for us, in the range assignment you can pre-calculate the assignment map by hand too, 'roundrobin' is difficult because it sorted the partition by partition's hashcode.  In our secor deployment, sometimes we see some kafka partitions don't have consumer owners, if we have easy-to-calculate map, we can quickly narrow down to a particular secor host to check it's log.

The two partition assignment code can be found in
https://apache.googlesource.com/kafka/+/4408f487ae911e29dbc6ef4d94010a6fad702109/core/src/main/scala/kafka/consumer/PartitionAssignor.scala

We are reverting the partition assignment from roundrobin back to range.  But leave a configuration parameter override if some people wants the roundrobin behavior.