### PR TITLE
Support user-defined upload policies

### DIFF
--- a/src/main/config/secor.dev.properties
+++ b/src/main/config/secor.dev.properties
@@ -34,8 +34,8 @@ kafka.seed.broker.port=9092
 zookeeper.quorum=localhost:2181
 
 # Upload policies.
-# 10K
-secor.max.file.size.bytes=10000
-# 10 seconds
-secor.max.file.age.seconds=10
-
+# Default upload policy
+secor.uploadpolicy.check.seconds=5
+secor.uploadpolicy.strategy.class=com.pinterest.secor.uploader.DefaultUploadPolicy
+# 10KB or 10 seconds (age of most recent file in a Secor partition)
+secor.uploadpolicy.properties=MAX_FILE_SIZE_BYTES=10000,MAX_FILE_AGE_SECONDS=10

--- a/src/main/config/secor.prod.properties
+++ b/src/main/config/secor.prod.properties
@@ -50,9 +50,9 @@ secor.swift.container=logsContainer
 ################
 
 # Upload policies.
-# 200MB
-secor.max.file.size.bytes=200000000
-# 1 hour
+# Default upload policy
+secor.uploadpolicy.check.seconds=600
+secor.uploadpolicy.strategy.class=com.pinterest.secor.uploader.DefaultUploadPolicy
+# 200MB or 1 hour (age of most recent file in a Secor partition)
 # for hourly ingestion/finalization, set this property to smaller value, e.g. 1800
-secor.max.file.age.seconds=3600
-
+secor.uploadpolicy.properties=MAX_FILE_SIZE_BYTES=200000000,MAX_FILE_AGE_SECONDS=3600

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -16,12 +16,13 @@
  */
 package com.pinterest.secor.common;
 
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.StringUtils;
-
-import java.util.Map;
-import java.util.Properties;
 
 /**
  * One-stop shop for Secor configuration options.
@@ -122,13 +123,17 @@ public class SecorConfig {
     public int getConsumerThreads() {
         return getInt("secor.consumer.threads");
     }
-
-    public long getMaxFileSizeBytes() {
-        return getLong("secor.max.file.size.bytes");
+    
+    public String getUploadPolicyStrategyClass() {
+    	return getString("secor.uploadpolicy.strategy.class");
     }
-
-    public long getMaxFileAgeSeconds() {
-        return getLong("secor.max.file.age.seconds");
+    
+    public long getUploadPolicyCheckSeconds() {
+    	return getLong("secor.uploadpolicy.check.seconds");
+    }
+    
+    public Map<String, String> getUploadPolicyProperties() {
+    	return getStringMap("secor.uploadpolicy.properties");
     }
 
     public long getOffsetsPerPartition() {
@@ -351,6 +356,10 @@ public class SecorConfig {
         checkProperty(name);
         return mProperties.getString(name);
     }
+    
+    private String getString(String name, String defaultValue) {
+        return mProperties.getString(name, defaultValue);
+    }
 
     private int getInt(String name) {
         checkProperty(name);
@@ -367,5 +376,13 @@ public class SecorConfig {
 
     private String[] getStringArray(String name) {
         return mProperties.getStringArray(name);
+    }
+    
+    private Map<String, String> getStringMap(String name) {
+    	Map<String, String> result = new HashMap<String, String>();
+    	for (Map.Entry<Object, Object> entry : mProperties.getProperties(name).entrySet()) {
+    		result.put(entry.getKey().toString(), entry.getValue().toString());
+    	}
+    	return result;
     }
 }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -16,13 +16,13 @@
  */
 package com.pinterest.secor.reader;
 
-import com.pinterest.secor.common.OffsetTracker;
-import com.pinterest.secor.common.SecorConfig;
-import com.pinterest.secor.common.TopicPartition;
-import com.pinterest.secor.message.Message;
-import com.pinterest.secor.util.IdUtil;
-import com.pinterest.secor.util.RateLimitUtil;
-import com.pinterest.secor.util.StatsUtil;
+import java.net.UnknownHostException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
 import kafka.consumer.Consumer;
 import kafka.consumer.ConsumerConfig;
 import kafka.consumer.ConsumerIterator;
@@ -31,15 +31,17 @@ import kafka.consumer.TopicFilter;
 import kafka.consumer.Whitelist;
 import kafka.javaapi.consumer.ConsumerConnector;
 import kafka.message.MessageAndMetadata;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.UnknownHostException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import com.pinterest.secor.common.OffsetTracker;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.TopicPartition;
+import com.pinterest.secor.message.Message;
+import com.pinterest.secor.util.IdUtil;
+import com.pinterest.secor.util.RateLimitUtil;
+import com.pinterest.secor.util.StatsUtil;
 
 /**
  * Message reader consumer raw Kafka messages.
@@ -52,7 +54,7 @@ public class MessageReader {
     private SecorConfig mConfig;
     private OffsetTracker mOffsetTracker;
     private ConsumerConnector mConsumerConnector;
-    private ConsumerIterator mIterator;
+    private ConsumerIterator<byte[], byte[]> mIterator;
     private HashMap<TopicPartition, Long> mLastAccessTime;
     private final int mTopicPartitionForgetSeconds;
     private final int mCheckMessagesPerSecond;
@@ -79,10 +81,10 @@ public class MessageReader {
     private void updateAccessTime(TopicPartition topicPartition) {
         long now = System.currentTimeMillis() / 1000L;
         mLastAccessTime.put(topicPartition, now);
-        Iterator iterator = mLastAccessTime.entrySet().iterator();
+        Iterator<Map.Entry<TopicPartition, Long>> iterator = mLastAccessTime.entrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry pair = (Map.Entry) iterator.next();
-            long lastAccessTime = (Long) pair.getValue();
+            Map.Entry<TopicPartition, Long> pair = iterator.next();
+            long lastAccessTime = pair.getValue();
             if (now - lastAccessTime > mTopicPartitionForgetSeconds) {
                 iterator.remove();
             }

--- a/src/main/java/com/pinterest/secor/uploader/AgeBasedUploadPolicy.java
+++ b/src/main/java/com/pinterest/secor/uploader/AgeBasedUploadPolicy.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.FileRegistry;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.TopicPartition;
+
+/**
+ * This policy uploads a TopicPartition whether the most recently created file is older than 'MAX_FILE_AGE_SECONDS'.
+ * Upload policy properties must be defined in the 'secor.uploadpolicy.properties' property.
+ * 
+ * @author Flavio Barata (flavio.barata@gmail.com)
+ */
+public class AgeBasedUploadPolicy extends UploadPolicy {
+
+	public AgeBasedUploadPolicy(SecorConfig config, FileRegistry fileRegistry) {
+		super(config, fileRegistry);
+	}
+
+	@Override
+	public boolean shouldUpload(TopicPartition topicPartition) throws Exception {
+        long modificationAgeSec = mFileRegistry.getModificationAgeSec(topicPartition);
+        long maxFileAgeSeconds = Long.parseLong(mConfig.getUploadPolicyProperties().get("MAX_FILE_AGE_SECONDS"));
+        
+		return modificationAgeSec >= maxFileAgeSeconds;
+	}
+
+}

--- a/src/main/java/com/pinterest/secor/uploader/DefaultUploadPolicy.java
+++ b/src/main/java/com/pinterest/secor/uploader/DefaultUploadPolicy.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.FileRegistry;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.TopicPartition;
+
+/**
+ * This policy combines two other policies: SizeBasedUploadPolicy and AgeBasedUploadPolicy.
+ * It uploads a TopicPartition if one OR other (or both) policy is satisfied.
+ * Upload policy properties must be defined in the 'secor.uploadpolicy.properties' property.
+ * 
+ * For example: secor.uploadpolicy.properties=MAX_FILE_SIZE_BYTES=200000000,MAX_FILE_AGE_SECONDS=3600
+ * 
+ * @see com.pinterest.secor.uploader.SizeBasedUploadPolicy
+ * @see com.pinterest.secor.uploader.AgeBasedUploadPolicy
+ * 
+ * @author Flavio Barata (flavio.barata@gmail.com)
+ */
+public class DefaultUploadPolicy extends UploadPolicy {
+	
+	private UploadPolicy mSizeBasedUploadPolicy;
+	private UploadPolicy mAgeBasedUploadPolicy;
+
+	public DefaultUploadPolicy(SecorConfig config, FileRegistry fileRegistry) {
+		super(config, fileRegistry);
+		
+		mSizeBasedUploadPolicy = new SizeBasedUploadPolicy(config, fileRegistry);
+		mAgeBasedUploadPolicy = new AgeBasedUploadPolicy(config, fileRegistry);
+	}
+
+	@Override
+	public boolean shouldUpload(TopicPartition topicPartition) throws Exception {
+		return mSizeBasedUploadPolicy.shouldUpload(topicPartition) ||
+				mAgeBasedUploadPolicy.shouldUpload(topicPartition);
+	}
+
+}

--- a/src/main/java/com/pinterest/secor/uploader/SizeBasedUploadPolicy.java
+++ b/src/main/java/com/pinterest/secor/uploader/SizeBasedUploadPolicy.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.FileRegistry;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.TopicPartition;
+
+/**
+ * This policy uploads a TopicPartition whether its size is larger than 'MAX_FILE_SIZE_BYTES'.
+ * Upload policy properties must be defined in the 'secor.uploadpolicy.properties' property.
+ * 
+ * @author Flavio Barata (flavio.barata@gmail.com)
+ */
+public class SizeBasedUploadPolicy extends UploadPolicy {
+
+	public SizeBasedUploadPolicy(SecorConfig config, FileRegistry fileRegistry) {
+		super(config, fileRegistry);
+	}
+
+	@Override
+	public boolean shouldUpload(TopicPartition topicPartition) throws Exception {
+		long size = mFileRegistry.getSize(topicPartition);
+		long maxFileSizeBytes = Long.parseLong(mConfig.getUploadPolicyProperties().get("MAX_FILE_SIZE_BYTES"));
+        
+		return size >= maxFileSizeBytes;
+	}
+
+}

--- a/src/main/java/com/pinterest/secor/uploader/TimeBasedUploadPolicy.java
+++ b/src/main/java/com/pinterest/secor/uploader/TimeBasedUploadPolicy.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.FileRegistry;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.TopicPartition;
+
+/**
+ * This policy uploads a TopicPartition every 'MAX_INTERVAL_SECONDS' seconds.
+ * Notice that the defined interval is subject to 'secor.uploadpolicy.check.seconds' property.
+ * Every time this upload policy is called (refer to the property above), it verifies if the interval between
+ * last upload and this call is greater than 'MAX_INTERVAL_SECONDS'.
+ * Upload policy properties must be defined in the 'secor.uploadpolicy.properties' property.
+ * 
+ * @author Flavio Barata (flavio.barata@gmail.com)
+ */
+public class TimeBasedUploadPolicy extends UploadPolicy {
+
+	private long mLastChecked;
+	
+	public TimeBasedUploadPolicy(SecorConfig config, FileRegistry fileRegistry) {
+		super(config, fileRegistry);
+		
+		mLastChecked = System.currentTimeMillis();
+	}
+
+	@Override
+	public boolean shouldUpload(TopicPartition topicPartition) throws Exception {
+		long now = System.currentTimeMillis();
+		long maxInterval = Integer.parseInt(mConfig.getUploadPolicyProperties().get("MAX_INTERVAL_SECONDS"));
+		
+		if ((now - mLastChecked) > maxInterval) {
+			mLastChecked = now;
+			return true;
+		}
+		
+		return false;
+	}
+
+}

--- a/src/main/java/com/pinterest/secor/uploader/UploadPolicy.java
+++ b/src/main/java/com/pinterest/secor/uploader/UploadPolicy.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.uploader;
+
+import com.pinterest.secor.common.FileRegistry;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.TopicPartition;
+
+/**
+ * Upload policies must inherit this class and implement 'shouldUpload' method.
+ * An UploadPolicy instance is responsible to define whether a given TopicPartition must be uploaded.
+ * The subclass of UploadPolicy to be used is loaded from 'secor.uploadpolicy.strategy.class' property.
+ * The 'shouldUpload' method is called periodically according to the value in 'secor.uploadpolicy.check.seconds'.
+ * Should the policy need to read any specific property, it can define using 'secor.uploadpolicy.properties'.
+ * Properties are in the form key1=value1,key2=value2.
+ * 
+ * @author Flavio Barata (flavio.barata@gmail.com)
+ */
+public abstract class UploadPolicy {
+
+	protected SecorConfig mConfig;
+	protected FileRegistry mFileRegistry;
+
+	public UploadPolicy(SecorConfig config, FileRegistry fileRegistry) {
+		mConfig = config;
+		mFileRegistry = fileRegistry;
+	}
+	
+	/**
+	 * This method must be implemented by all policies and should return <code>true</code> whether a given TopicPartition is to be uploaded.
+	 * @param topicPartition The TopicPartition to be (or not) uploaded.
+	 * @return <code>true</code> if a TopicPartition must be uploaded.
+	 * @throws Exception
+	 */
+	public abstract boolean shouldUpload(TopicPartition topicPartition) throws Exception;
+}

--- a/src/main/java/com/pinterest/secor/util/ReflectionUtil.java
+++ b/src/main/java/com/pinterest/secor/util/ReflectionUtil.java
@@ -16,15 +16,15 @@
  */
 package com.pinterest.secor.util;
 
+import org.apache.hadoop.io.compress.CompressionCodec;
+
 import com.pinterest.secor.common.LogFilePath;
 import com.pinterest.secor.common.SecorConfig;
-
 import com.pinterest.secor.io.FileReader;
-import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.io.FileReaderWriterFactory;
+import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.parser.MessageParser;
 import com.pinterest.secor.uploader.UploadManager;
-import org.apache.hadoop.io.compress.CompressionCodec;
 
 /**
  * ReflectionUtil implements utility methods to construct objects of classes
@@ -34,6 +34,7 @@ import org.apache.hadoop.io.compress.CompressionCodec;
  * @author Silas Davis (github-code@silasdavis.net)
  */
 public class ReflectionUtil {
+	
     /**
      * Create an UploadManager from its fully qualified class name.
      *
@@ -49,14 +50,7 @@ public class ReflectionUtil {
      */
     public static UploadManager createUploadManager(String className,
                                                     SecorConfig config) throws Exception {
-        Class<?> clazz = Class.forName(className);
-        if (!UploadManager.class.isAssignableFrom(clazz)) {
-            throw new IllegalArgumentException(String.format("The class '%s' is not assignable to '%s'.",
-                    className, UploadManager.class.getName()));
-        }
-
-        // Assume that subclass of UploadManager has a constructor with the same signature as UploadManager
-        return (UploadManager) clazz.getConstructor(SecorConfig.class).newInstance(config);
+        return createClass(className, UploadManager.class, config);
     }
 
     /**
@@ -73,36 +67,7 @@ public class ReflectionUtil {
      */
     public static MessageParser createMessageParser(String className,
                                                     SecorConfig config) throws Exception {
-        Class<?> clazz = Class.forName(className);
-        if (!MessageParser.class.isAssignableFrom(clazz)) {
-            throw new IllegalArgumentException(String.format("The class '%s' is not assignable to '%s'.",
-                    className, MessageParser.class.getName()));
-        }
-
-        // Assume that subclass of MessageParser has a constructor with the same signature as MessageParser
-        return (MessageParser) clazz.getConstructor(SecorConfig.class).newInstance(config);
-    }
-
-    /**
-     * Create a FileReaderWriterFactory that is able to read and write a specific type of output log file.
-     * The class passed in by name must be assignable to FileReaderWriterFactory.
-     * Allows for pluggable FileReader and FileWriter instances to be constructed for a particular type of log file.
-     *
-     * See the secor.file.reader.writer.factory config option.
-     *
-     * @param className the class name of a subclass of FileReaderWriterFactory
-     * @return a FileReaderWriterFactory with the runtime type of the class passed by name
-     * @throws Exception
-     */
-    private static FileReaderWriterFactory createFileReaderWriterFactory(String className) throws Exception {
-        Class<?> clazz = Class.forName(className);
-        if (!FileReaderWriterFactory.class.isAssignableFrom(clazz)) {
-            throw new IllegalArgumentException(String.format("The class '%s' is not assignable to '%s'.",
-                    className, FileReaderWriterFactory.class.getName()));
-        }
-
-        // We assume a parameterless constructor
-        return (FileReaderWriterFactory) clazz.newInstance();
+        return createClass(className, MessageParser.class, config);
     }
 
     /**
@@ -115,9 +80,8 @@ public class ReflectionUtil {
      * @throws Exception
      */
     public static FileWriter createFileWriter(String className, LogFilePath logFilePath,
-                                              CompressionCodec codec)
-            throws Exception {
-        return createFileReaderWriterFactory(className).BuildFileWriter(logFilePath, codec);
+                                              CompressionCodec codec) throws Exception {
+        return createClass(className, FileReaderWriterFactory.class).BuildFileWriter(logFilePath, codec);
     }
 
     /**
@@ -130,8 +94,30 @@ public class ReflectionUtil {
      * @throws Exception
      */
     public static FileReader createFileReader(String className, LogFilePath logFilePath,
-                                              CompressionCodec codec)
-            throws Exception {
-        return createFileReaderWriterFactory(className).BuildFileReader(logFilePath, codec);
+                                              CompressionCodec codec) throws Exception {
+        return createClass(className, FileReaderWriterFactory.class).BuildFileReader(logFilePath, codec);
     }
+
+    /**
+     * Instantiate a class specified by className using its constructor that matches parameters.
+     * The className must be a subclass of classType.
+     * 
+     * @param className the class name of a subclass of classType to be instantiated
+     * @param classType the class type corresponding to the className
+     * @param parameters optional parameters to be used in the constructor of className
+     * @return the instantiated class
+     * @throws Exception
+     */
+	private static <T> T createClass(String className, Class<T> classType, Object... parameters) throws Exception {
+		Class<?> clazz = Class.forName(className);
+		if (!classType.isAssignableFrom(clazz)) {
+			throw new IllegalArgumentException(String.format("The class '%s' is not assignable to '%s'.",
+					className, classType.getName()));
+		}
+		Class<?>[] classes = new Class<?>[parameters.length];
+		for (int i = 0; i < classes.length; i++) {
+			classes[i] = parameters[i].getClass();
+		}
+		return (T) clazz.getConstructor(classes).newInstance(parameters);
+	}
 }

--- a/src/main/java/com/pinterest/secor/util/ReflectionUtil.java
+++ b/src/main/java/com/pinterest/secor/util/ReflectionUtil.java
@@ -18,6 +18,7 @@ package com.pinterest.secor.util;
 
 import org.apache.hadoop.io.compress.CompressionCodec;
 
+import com.pinterest.secor.common.FileRegistry;
 import com.pinterest.secor.common.LogFilePath;
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.io.FileReader;
@@ -25,6 +26,7 @@ import com.pinterest.secor.io.FileReaderWriterFactory;
 import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.parser.MessageParser;
 import com.pinterest.secor.uploader.UploadManager;
+import com.pinterest.secor.uploader.UploadPolicy;
 
 /**
  * ReflectionUtil implements utility methods to construct objects of classes
@@ -32,9 +34,16 @@ import com.pinterest.secor.uploader.UploadManager;
  *
  * @author Pawel Garbacki (pawel@pinterest.com)
  * @author Silas Davis (github-code@silasdavis.net)
+ * @author Flavio Barata (flavio.barata@gmail.com)
  */
 public class ReflectionUtil {
 	
+	public static UploadPolicy createUploadPolicy(String className,
+			SecorConfig config,
+			FileRegistry fileRegistry) throws Exception {
+		return createClass(className, UploadPolicy.class, config, fileRegistry);
+	}
+
     /**
      * Create an UploadManager from its fully qualified class name.
      *

--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -379,7 +379,7 @@ move_offset_back_test() {
     initialize
 
     OLD_ADDITIONAL_OPTS=${ADDITIONAL_OPTS}
-    ADDITIONAL_OPTS="${ADDITIONAL_OPTS} -Dsecor.max.file.age.seconds=30"
+    ADDITIONAL_OPTS="${ADDITIONAL_OPTS} -Dsecor.uploadpolicy.properties=MAX_FILE_SIZE_BYTES=10000,MAX_FILE_AGE_SECONDS=30"
 
     start_secor
     sleep 3

--- a/src/test/java/com/pinterest/secor/util/ReflectionUtilTest.java
+++ b/src/test/java/com/pinterest/secor/util/ReflectionUtilTest.java
@@ -16,18 +16,26 @@
  */
 package com.pinterest.secor.util;
 
+import junit.framework.TestCase;
+
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+
 import com.pinterest.secor.common.LogFilePath;
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.parser.MessageParser;
-import org.apache.commons.configuration.PropertiesConfiguration;
-import org.junit.Test;
 
-public class ReflectionUtilTest {
+@RunWith(PowerMockRunner.class)
+public class ReflectionUtilTest extends TestCase {
 
     private SecorConfig mSecorConfig;
     private LogFilePath mLogFilePath;
 
+    @Override
     public void setUp() throws Exception {
+    	super.setUp();
         PropertiesConfiguration properties = new PropertiesConfiguration();
         mSecorConfig = new SecorConfig(properties);
         mLogFilePath = new LogFilePath("/foo", "/foo/bar/baz/1_1_1");


### PR DESCRIPTION
This PR adds support for user-defined upload policies. The upload policy must inherits abstract class UploadPolicy and implement 'shouldUpload(TopicPartition)' method. The subclass to be used as current policy is loaded from 'secor.uploadpolicy.strategy.class' property. Furthermore, an additional property 'secor.uploadpolicy.check.seconds' is used to determine how often the policy should be called.

Should the policy need to read any specific property, it can use 'secor.uploadpolicy.properties'. Properties are in the form key1=value1,key2=value2.

For example:

```
secor.uploadpolicy.check.seconds=600
secor.uploadpolicy.strategy.class=com.pinterest.secor.uploader.DefaultUploadPolicy
secor.uploadpolicy.properties=MAX_FILE_SIZE_BYTES=200000000,MAX_FILE_AGE_SECONDS=3600
```

In short, default values do not modify current Secor behavior. Therefore, DefaultUploadPolicy#shouldUpload() returns true if (size >= MAX_FILE_SIZE_BYTES OR modificationAgeSec >= MAX_FILE_AGE_SECONDS).

The following two properties were removed in order to use the new introduced model:

```
secor.max.file.size.bytes
secor.max.file.age.seconds
```
