### PR TITLE
Handle the OutOfMemoryError caused by corrupted messages

### DIFF
--- a/src/main/java/com/pinterest/secor/consumer/Consumer.java
+++ b/src/main/java/com/pinterest/secor/consumer/Consumer.java
@@ -139,7 +139,7 @@ public class Consumer extends Thread {
                 parsedMessage = mMessageParser.parse(rawMessage);
                 final double DECAY = 0.999;
                 mUnparsableMessages *= DECAY;
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 mUnparsableMessages++;
                 final double MAX_UNPARSABLE_MESSAGES = 1000.;
                 if (mUnparsableMessages > MAX_UNPARSABLE_MESSAGES) {


### PR DESCRIPTION
Occasionaly there are corrupted messages caused by upstream job, these corrupted messages caused OOMError during thrift deserialization which stopped secor pipeline.

Changed the caught exception to also Error to capture OOMError.

For example, this is one of the OOM we saw:

java.lang.OutOfMemoryError: Java heap space

        at org.apache.thrift.protocol.TBinaryProtocol.readBinary(TBinaryProtocol.java:371)

        at org.apache.thrift.protocol.TProtocolUtil.skip(TProtocolUtil.java:109)

        at org.apache.thrift.protocol.TProtocolUtil.skip(TProtocolUtil.java:131)

        at org.apache.thrift.protocol.TProtocolUtil.skip(TProtocolUtil.java:60)

        at org.apache.thrift.TDeserializer.locateField(TDeserializer.java:319)

        at org.apache.thrift.TDeserializer.partialDeserializeField(TDeserializer.java:237)

        at org.apache.thrift.TDeserializer.partialDeserializeI64(TDeserializer.java:184)

        at com.pinterest.secor.parser.ThriftMessageParser.extractTimestampMillis(ThriftMessageParser.java:56)

        at com.pinterest.secor.parser.TimestampedMessageParser.extractPartitions(TimestampedMessageParser.java:98)