### PR TITLE
Backward compatibility fix and GS compatibility fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/pinterest/secor.svg)](https://travis-ci.org/pinterest/secor)
 
-Secor is a service persisting [Kafka] logs to [Amazon S3] and [Openstack Swift].
+Secor is a service persisting [Kafka] logs to [Amazon S3], [Google Cloud Storage] and [Openstack Swift].
 
 ## Key features
   - **strong consistency**: as long as [Kafka] is not dropping messages (e.g., due to aggressive cleanup policy) before Secor is able to read them, it is guaranteed that each message will be saved in exactly one [S3] file. This property is not compromised by the notorious temporal inconsistency of [S3] caused by the [eventual consistency] model,
@@ -138,6 +138,7 @@ If you have any questions or comments, you can reach us at [secor-users@googlegr
 [Kafka]:http://kafka.apache.org/
 [Amazon S3]:http://aws.amazon.com/s3/
 [S3]:http://aws.amazon.com/s3/
+[Google Cloud Storage]:https://cloud.google.com/storage/
 [eventual consistency]:http://docs.aws.amazon.com/AmazonS3/latest/dev/Introduction.html#ConsistencyMode
 [Hive]:http://hive.apache.org/
 [Ostrich]: https://github.com/twitter/ostrich

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -21,7 +21,7 @@
 secor.kafka.topic_filter=.*
 
 # Choose what to fill according to the service you are using
-# in the choice option you MUST fill S3 or Swift
+# in the choice option you can fill S3, GS or Swift
 cloud.service=S3
 
 # AWS authentication credentials.
@@ -29,23 +29,10 @@ cloud.service=S3
 aws.access.key=
 aws.secret.key=
 
-# Swift Login Details:
-swift.use.get.auth=true
-swift.auth.url=
-swift.tenant=
-swift.username=
-swift.port=8080
-swift.public=true
-
-# only needed if "swift.use.get.auth" = false
-swift.password=
-
-# only needed if "swift.use.get.auth" = true
-swift.api.key=
-
 ################
 # END MUST SET #
 ################
+
 
 # AWS region or endpoint. region should be a known region name (eg.
 # us-east-1). endpoint should be a known S3 endpoint url. If neither
@@ -62,6 +49,30 @@ aws.endpoint=
 # Hadoop filesystem to use. Choices are s3n or s3a.
 # See https://wiki.apache.org/hadoop/AmazonS3 for details.
 secor.s3.filesystem=s3n
+
+# Swift config, MUST configure if cloud.service=Swift
+
+# Swift Login Details:
+swift.use.get.auth=true
+swift.auth.url=
+swift.tenant=
+swift.username=
+swift.port=8080
+swift.public=true
+
+# only needed if "swift.use.get.auth" = false
+swift.password=
+
+# only needed if "swift.use.get.auth" = true
+swift.api.key=
+
+# GS config, MUST configure if gcloud.service=GS
+
+# Name of the Google cloud storage bucket where log files are stored.
+secor.gs.bucket=secor_gs
+
+# Google cloud storage path where files are stored within the bucket.
+secor.gs.path=data
 
 # Zookeeper config.
 zookeeper.session.timeout.ms=3000

--- a/src/main/config/secor.dev.gs.properties
+++ b/src/main/config/secor.dev.gs.properties
@@ -10,12 +10,12 @@ secor.upload.manager.class=com.pinterest.secor.uploader.GsUploadManager
 # Name of the Google cloud storage bucket where log files are stored.
 secor.gs.bucket=secor_gs
 
+# Google cloud storage path where files are stored within the bucket.
+secor.gs.path=data
+
 ################
 # END MUST SET #
 ################
-
-# Google cloud storage path where files are stored within the bucket.
-secor.gs.path=data
 
 # Application credentials configuration file
 # https://developers.google.com/identity/protocols/application-default-credentials

--- a/src/main/java/com/pinterest/secor/util/FileUtil.java
+++ b/src/main/java/com/pinterest/secor/util/FileUtil.java
@@ -39,8 +39,8 @@ public class FileUtil {
 
     public static void configure(SecorConfig config) {
         if (config != null) {
-            if (config.getCloudService().equals("Swift")){
-                mConf.set("fs.swift.impl","org.apache.hadoop.fs.swift.snative.SwiftNativeFileSystem");
+            if (config.getCloudService().equals("Swift")) {
+                mConf.set("fs.swift.impl", "org.apache.hadoop.fs.swift.snative.SwiftNativeFileSystem");
                 mConf.set("fs.swift.service.GENERICPROJECT.auth.url", config.getSwiftAuthUrl());
                 mConf.set("fs.swift.service.GENERICPROJECT.username", config.getSwiftUsername());
                 mConf.set("fs.swift.service.GENERICPROJECT.tenant", config.getSwiftTenant());
@@ -52,7 +52,7 @@ public class FileUtil {
                 } else {
                     mConf.set("fs.swift.service.GENERICPROJECT.password", config.getSwiftPassword());
                 }
-            } else {
+            } else if (config.getCloudService().equals("S3")) {
                 if (config.getAwsAccessKey().isEmpty() != config.getAwsSecretKey().isEmpty()) {
                     throw new IllegalArgumentException(
                         "Must specify both aws.access.key and aws.secret.key or neither.");
@@ -86,8 +86,10 @@ public class FileUtil {
                 container = config.getSwiftContainer();
             }
             prefix = "swift://" + container + ".GENERICPROJECT/" + config.getSwiftPath();
-        } else {
+        } else if (config.getCloudService().equals("S3")) {
             prefix = "s3n://" + config.getS3Bucket() + "/" + config.getS3Path();
+        } else if (config.getCloudService().equals("GS")) {
+            prefix = "gs://" + config.getGsBucket() + "/" + config.getGsPath();
         }
         return prefix;
     }
@@ -101,7 +103,8 @@ public class FileUtil {
         if (statuses != null) {
             for (FileStatus status : statuses) {
                 Path statusPath = status.getPath();
-                if (path.startsWith("s3://") || path.startsWith("s3n://") || path.startsWith("s3a://") || path.startsWith("swift://")) {
+                if (path.startsWith("s3://") || path.startsWith("s3n://") || path.startsWith("s3a://") ||
+                        path.startsWith("swift://") || path.startsWith("gs://")) {
                     paths.add(statusPath.toUri().toString());
                 } else {
                     paths.add(statusPath.toUri().getPath());
@@ -169,7 +172,8 @@ public class FileUtil {
             for (FileStatus fileStatus : statuses) {
                 Path statusPath = fileStatus.getPath();
                 String stringPath;
-                if (path.startsWith("s3://") || path.startsWith("s3n://") || path.startsWith("s3a://") || path.startsWith("swift://")) {
+                if (path.startsWith("s3://") || path.startsWith("s3n://") || path.startsWith("s3a://") ||
+                        path.startsWith("swift://") || path.startsWith("gs://")) {
                     stringPath = statusPath.toUri().toString();
                 } else {
                     stringPath = statusPath.toUri().getPath();

--- a/src/test/java/com/pinterest/secor/util/FileUtilTest.java
+++ b/src/test/java/com/pinterest/secor/util/FileUtilTest.java
@@ -27,6 +27,7 @@ public class FileUtilTest {
 
     private SecorConfig mSwiftConfig;
     private SecorConfig mS3Config;
+    private SecorConfig mGSconfig;
 
     @Before
     public void setUp() throws Exception {
@@ -39,7 +40,12 @@ public class FileUtilTest {
         mS3Config = Mockito.mock(SecorConfig.class);
         Mockito.when(mS3Config.getCloudService()).thenReturn("S3");
         Mockito.when(mS3Config.getS3Bucket()).thenReturn("some_bucket");
-        Mockito.when(mS3Config.getS3Path()).thenReturn("some_s3_parent_dir"); 
+        Mockito.when(mS3Config.getS3Path()).thenReturn("some_s3_parent_dir");
+
+        mGSconfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mGSconfig.getCloudService()).thenReturn("GS");
+        Mockito.when(mGSconfig.getGsBucket()).thenReturn("some_gs_bucket");
+        Mockito.when(mGSconfig.getGsPath()).thenReturn("some_gs_parent_dir");
     }
 
     @Test
@@ -51,6 +57,10 @@ public class FileUtilTest {
         //FileUtil.configure(mS3Config);
         Assert.assertEquals(FileUtil.getPrefix("some_topic", mS3Config),
                 "s3n://some_bucket/some_s3_parent_dir");
+
+        //FileUtil.configure(mGSConfig);
+        Assert.assertEquals(FileUtil.getPrefix("some_topic", mGSconfig),
+                "gs://some_gs_bucket/some_gs_parent_dir");
 
         // return to the previous state
         FileUtil.configure(null);


### PR DESCRIPTION
The introduction of cloud.service was being to restrictive when adding new kind of service (IE: Google cloud storage) always fallbacking to S3 for validation and such. I made it optional (but more validation when specifying it) so it could be more flexible. 