### PR TITLE
[URGENT] Bugfix: SimpleDateFormat are NOT thread-safe

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
@@ -34,15 +34,14 @@ public abstract class TimestampedMessageParser extends MessageParser implements 
     private static final long HOUR_IN_MILLIS = 3600L * 1000L;
     private static final long DAY_IN_MILLIS = 3600L * 24 * 1000L;
 
-    private static final SimpleDateFormat mDtFormatter = new SimpleDateFormat("yyyy-MM-dd");
-    private static final SimpleDateFormat mHrFormatter = new SimpleDateFormat("HH");
-    private static final SimpleDateFormat mDtHrFormatter = new SimpleDateFormat("yyyy-MM-dd-HH");
-
-    static {
-        mDtFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-        mHrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-        mDtHrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
+    /*
+     * IMPORTANT
+     * SimpleDateFormat are NOT thread-safe.
+     * Each parser needs to have their own local SimpleDateFormat or it'll cause race condition.
+     */
+    private final SimpleDateFormat mDtFormatter;
+    private final SimpleDateFormat mHrFormatter;
+    private final SimpleDateFormat mDtHrFormatter;
 
     private final boolean mUsingHourly;
 
@@ -50,6 +49,13 @@ public abstract class TimestampedMessageParser extends MessageParser implements 
         super(config);
         mUsingHourly = usingHourly(config);
         LOG.info("UsingHourly: {}", mUsingHourly);
+
+        mDtFormatter = new SimpleDateFormat("yyyy-MM-dd");
+        mDtFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mHrFormatter = new SimpleDateFormat("HH");
+        mHrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mDtHrFormatter = new SimpleDateFormat("yyyy-MM-dd-HH");
+        mDtHrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
 
     public abstract long extractTimestampMillis(final Message message) throws Exception;


### PR DESCRIPTION
I was having bug with message with timestamp like `1448554347` 2015-11-26 going into buckets `dt=2015-03-16`.

After a day of investigation; I found that `TimestampedMessageParser` is using static `SimpleDateFormat` but when looking at the documentation I've found;

```
 * Date formats are not synchronized.
 * It is recommended to create separate format instances for each thread.
 * If multiple threads access a format concurrently, it must be synchronized
 * externally.
```

SimpleDateFormat is not thread-safe and thus each thread need to have their own instance to avoid having weird race conditions with messages going in the wrong grouping bucket.