### PR TITLE
Use the strict UNIX_LINES mode to do regular expression parsing

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/RegexMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/RegexMessageParser.java
@@ -39,7 +39,7 @@ public class RegexMessageParser extends TimestampedMessageParser {
         super(config);
         String patStr = config.getMessageTimestampInputPattern();
         LOG.info("timestamp pattern: {}", patStr);
-        mTsPattern = Pattern.compile(patStr);
+        mTsPattern = Pattern.compile(patStr, Pattern.UNIX_LINES);
     }
 
     @Override


### PR DESCRIPTION
Recently we added RegexMessageParser to parse the text log file, occasionally I saw the error message about cannot parsing some messages.

After investigation, I realized that the problem is some text log contain non-standard unicode (e.g. 0x85) in the url field, these 0x85 char are being treated as newline in java.text.Pattern.

Fix this by using strict UNIX line parsing (i.e. only recognize 0x0a as the line terminator)