### PR TITLE
Make the finalizer delay to be a configuration parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.pinterest</groupId>
     <artifactId>secor</artifactId>
-    <version>0.7-SNAPSHOT</version>
+    <version>0.8-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>secor</name>
     <description>Kafka to s3/gs/swift logs exporter</description>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -147,6 +147,9 @@ secor.topic_partition.forget.seconds=600
 # The hour folder ranges from 00 to 23
 # partitioner.granularity.hour=true
 
+# how many seconds should the finalizer wait to finalize a partition
+partitioner.finalizer.delay.seconds=3600
+
 # During partition finalization, the finalizer will start from the last
 # time partition (e.g. dt=2015-07-17) and traverse backwards for n 
 # partition periods (e.g. dt=2015-07-16, dt=2015-07-15 ...)

--- a/src/main/java/com/pinterest/secor/common/KafkaClient.java
+++ b/src/main/java/com/pinterest/secor/common/KafkaClient.java
@@ -59,7 +59,7 @@ public class KafkaClient {
     private HostAndPort findLeader(TopicPartition topicPartition) {
         SimpleConsumer consumer = null;
         try {
-            LOG.info("looking up leader for topic {} partition {}", topicPartition.getTopic(), topicPartition.getPartition());
+            LOG.debug("looking up leader for topic {} partition {}", topicPartition.getTopic(), topicPartition.getPartition());
             consumer = createConsumer(
                 mConfig.getKafkaSeedBrokerHost(),
                 mConfig.getKafkaSeedBrokerPort(),
@@ -113,7 +113,7 @@ public class KafkaClient {
 
     private Message getMessage(TopicPartition topicPartition, long offset,
                                SimpleConsumer consumer) {
-        LOG.info("fetching message topic {} partition {} offset ",
+        LOG.debug("fetching message topic {} partition {} offset ",
                 topicPartition.getTopic(), topicPartition.getPartition(), offset);
         final int MAX_MESSAGE_SIZE_BYTES = mConfig.getMaxMessageSizeBytes();
         final String clientName = getClientName(topicPartition);
@@ -151,7 +151,7 @@ public class KafkaClient {
 
     public SimpleConsumer createConsumer(TopicPartition topicPartition) {
         HostAndPort leader = findLeader(topicPartition);
-        LOG.info("leader for topic {} partition {} is {}", topicPartition.getTopic(), topicPartition.getPartition(), leader.toString());
+        LOG.debug("leader for topic {} partition {} is {}", topicPartition.getTopic(), topicPartition.getPartition(), leader.toString());
         final String clientName = getClientName(topicPartition);
         return createConsumer(leader.getHostText(), leader.getPort(), clientName);
     }

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -336,6 +336,10 @@ public class SecorConfig {
         return getInt("secor.gs.read.timeout.ms", 3 * 60000);
     }
 
+    public int getFinalizerDelaySeconds() {
+        return getInt("partitioner.finalizer.delay.seconds");
+    }
+
     public boolean getBoolean(String name, boolean defaultValue) {
         return mProperties.getBoolean(name, defaultValue);
     }

--- a/src/test/java/com/pinterest/secor/parser/JsonMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/JsonMessageParserTest.java
@@ -42,6 +42,7 @@ public class JsonMessageParserTest extends TestCase {
     public void setUp() throws Exception {
         mConfig = Mockito.mock(SecorConfig.class);
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getFinalizerDelaySeconds()).thenReturn(3600);
 
         byte messageWithSecondsTimestamp[] =
                 "{\"timestamp\":\"1405911096\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");


### PR DESCRIPTION
Make the finalizer delay to be a configuration parameter
We used to have hard-coded 3600 seconds delay before the partition can be finalized to allow for late-arrival events.

Some use cases (e.g. hourly pull) want shorter delay time (e.g. 15 minutes).

Make this parameter a configuration.