### PR TITLE
Add a new config to allow more flexible mapping from kafka topic to h…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.pinterest</groupId>
     <artifactId>secor</artifactId>
-    <version>0.9-SNAPSHOT</version>
+    <version>0.10-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>secor</name>
     <description>Kafka to s3/gs/swift logs exporter</description>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -166,10 +166,16 @@ secor.local.log.delete.age.hours=-1
 # It is available at https://api.qubole.com/users/edit
 qubole.api.token=
 
-# hive tables are generally named after the topics. For instance if the topic is request_log
-# the hive table is also called request_log. If you want this to be pinlog_request_log you can
-# set this config to "pinlog_". This affects all topics.
+# hive tables are generally named after the topics. For instance if the topic 
+# is request_log the hive table is also called request_log. If you want this 
+# to be pinlog_request_log you can set this config to "pinlog_". This affects 
+# all topics.
 hive.table.prefix=
+
+# You can also name your hive table directly if your hive table doesn't 
+# follow the pattern of <hive.table.prefix><kafka topic>
+# E.g.  hive.table.name.topic1=table1 to indicate that hive table for 
+# kafka topic <topic1> will be named <table1>
 
 # Secor can export stats such as consumption lag (in seconds and offsets) per topic partition.
 # Leave empty to disable this functionality.

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -296,6 +296,11 @@ public class SecorConfig {
         return getString("secor.hive.prefix"); 
     }
 
+    public String getHiveTableName(String topic) {
+        String key = "secor.hive.table.name." + topic;
+        return mProperties.getString(key, null);
+    }
+
     public String getCompressionCodec() {
         return getString("secor.compression.codec");
     }

--- a/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
+++ b/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
@@ -150,14 +150,21 @@ public class PartitionFinalizer {
                         sb.append("'");
                     }
                     LOG.info("Hive partition string: " + sb);
-                    String hivePrefix = null;
-                    try {
-                        hivePrefix = mConfig.getHivePrefix();
-                    } catch (RuntimeException ex) {
-                        LOG.warn("HivePrefix is not defined.  Skip hive registration");
+
+                    String hiveTableName = mConfig.getHiveTableName(topic);
+                    LOG.info("Hive table name from config: {}", hiveTableName);
+                    if (hiveTableName == null) {
+                        String hivePrefix = null;
+                        try {
+                            hivePrefix = mConfig.getHivePrefix();
+                        } catch (RuntimeException ex) {
+                            LOG.warn("HivePrefix is not defined.  Skip hive registration");
+                        }
+                        hiveTableName = hivePrefix + topic;
+                        LOG.info("Hive table name from prefix: {}", hiveTableName);
                     }
-                    if (hivePrefix != null) {
-                        mQuboleClient.addPartition(hivePrefix + topic, sb.toString());
+                    if (hiveTableName != null) {
+                        mQuboleClient.addPartition(hiveTableName, sb.toString());
                     }
                 } catch (Exception e) {
                     LOG.error("failed to finalize topic " + topic, e);


### PR DESCRIPTION
…ive table name

Currently, we have secor.hive.prefix to allow people adding prefix to a kakfa topic name when mapping to hive table name.  Sometimes, people have an existing hive table name which doesn't fall in into the prefix pattern.  Add new config 'secor.hive.table.name.topic1=table1' to map topic name to arbituary hive table name.  This is an optional config, the existence of this property will override the hive.table.prefix property.