### PR TITLE
Add support for timestamps in fields beyond the first to Thrift date parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ One of the convenience features of Secor is the ability to group messages and sa
 
 - **offset parser**: parser that groups messages based on offset ranges. E.g., messages with offsets in range 0 to 999 will end up under ```s3n://bucket/topic/offset=0/```, offsets 1000 to 2000 will go to ```s3n://bucket/topic/offset=1000/```. To use this parser, start Secor with properties file [secor.prod.backup.properties](src/main/config/secor.prod.backup.properties).
 
-- **thrift date parser**: parser that extracts timestamps from thrift messages and groups the output based on the date (at a day granularity). To keep things simple, this parser assumes that the timestamp is carried in the first field (id 1) of the thrift message schema. The timestamp may be expressed either in seconds or milliseconds, or nanoseconds since the epoch. The output goes to date-partitioned paths (e.g., ```s3n://bucket/topic/dt=2014-05-01```, ```s3n://bucket/topic/dt=2014-05-02```). Date partitioning is particularly convenient if the output is to be consumed by ETL tools such as [Hive]. To use this parser, start Secor with properties file [secor.prod.partition.properties](src/main/config/secor.prod.partition.properties). You may override the field used to extract the timestamp by setting the "message.timestamp.name" property.
+- **thrift date parser**: parser that extracts timestamps from thrift messages and groups the output based on the date (at a day granularity). To keep things simple, this parser assumes that the timestamp is carried in the first field (id 1) of the thrift message schema by default. The field id can be changed by setting ```message.timestamp.id``` as long as the field is at the top level of the thrift object (i.e. it is not in a nested structure). The timestamp may be expressed either in seconds or milliseconds, or nanoseconds since the epoch. The output goes to date-partitioned paths (e.g., ```s3n://bucket/topic/dt=2014-05-01```, ```s3n://bucket/topic/dt=2014-05-02```). Date partitioning is particularly convenient if the output is to be consumed by ETL tools such as [Hive]. To use this parser, start Secor with properties file [secor.prod.partition.properties](src/main/config/secor.prod.partition.properties). Note the ```message.timestamp.name``` property has no effect on the thrift parsing, which is determined by the field id.
 
 - **JSON date parser**: parser that extracts timestamps from JSON messages and groups the output based on the date, similar to the Thrift parser above. To use this parser, start Secor with properties file [secor.prod.partition.properties](src/main/config/secor.prod.partition.properties) and set `secor.message.parser.class=com.pinterest.secor.parser.JsonMessageParser`. You may override the field used to extract the timestamp by setting the "message.timestamp.name" property.
 
@@ -130,6 +130,7 @@ Secor is distributed under [Apache License, Version 2.0](http://www.apache.org/l
   * [TiVo](https://www.tivo.com)
   * [Yelp](http://www.yelp.com)
   * [VarageSale](http://www.varagesale.com)
+  * [Skyscanner](http://www.skyscanner.net)
 
 ## Help
 

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -218,6 +218,14 @@ statsd.hostport=
 # Name of field that contains timestamp for JSON, MessagePack, or Thrift message parser. (1405970352123)
 message.timestamp.name=timestamp
 
+# Field ID of the field that contains timestamp for Thrift message parser.
+# N.B. setting this past 1 will come with a performance penalty
+message.timestamp.id=1
+
+# Data type of the timestamp field for thrift message parser.
+# Supports i64 and i32.
+message.timestamp.type=i64
+
 # Name of field that contains a timestamp, as a date Format, for JSON. (2014-08-07, Jul 23 02:16:57 2005, etc...)
 # Should be used when there is no timestamp in a Long format. Also ignore time zones.
 message.timestamp.input.pattern=

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -296,6 +296,14 @@ public class SecorConfig {
         return getString("message.timestamp.name");
     }
 
+    public int getMessageTimestampId() {
+        return getInt("message.timestamp.id");
+    }
+
+    public String getMessageTimestampType() {
+        return getString("message.timestamp.type");
+    }
+
     public String getMessageTimestampInputPattern() {
         return getString("message.timestamp.input.pattern");
     }

--- a/src/test/java/com/pinterest/secor/parser/ThriftMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/ThriftMessageParserTest.java
@@ -1,0 +1,79 @@
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import junit.framework.TestCase;
+import org.apache.thrift.TSerializer;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.pinterest.secor.thrift.UnitTestMessage;
+
+@RunWith(PowerMockRunner.class)
+public class ThriftMessageParserTest extends TestCase {
+    private SecorConfig mConfig;
+
+    @Override
+    public void setUp() throws Exception {
+        mConfig = Mockito.mock(SecorConfig.class);
+    }
+
+    private Message buildMessage(long timestamp, int timestampTwo, long timestampThree) throws Exception {
+        UnitTestMessage thriftMessage = new UnitTestMessage(timestamp, "notimportant", timestampTwo, timestampThree);
+        TSerializer serializer = new TSerializer(new TBinaryProtocol.Factory());
+        byte[] data = serializer.serialize(thriftMessage);
+
+        return new Message("test", 0, 0, null, data);
+    }
+
+    @Test
+    public void testExtractTimestamp() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("blasdjlkjasdkl");
+        Mockito.when(mConfig.getMessageTimestampId()).thenReturn(1);
+        Mockito.when(mConfig.getMessageTimestampType()).thenReturn("i64");
+
+        ThriftMessageParser parser = new ThriftMessageParser(mConfig);
+
+        assertEquals(1405970352000L, parser.extractTimestampMillis(buildMessage(1405970352L, 1, 2L)));
+        assertEquals(1405970352123L, parser.extractTimestampMillis(buildMessage(1405970352123L, 1, 2L)));
+    }
+
+    @Test
+    public void testExtractTimestampTwo() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestampTwo");
+        Mockito.when(mConfig.getMessageTimestampId()).thenReturn(3);
+        Mockito.when(mConfig.getMessageTimestampType()).thenReturn("i32");
+
+        ThriftMessageParser parser = new ThriftMessageParser(mConfig);
+
+        assertEquals(1405970352000L, parser.extractTimestampMillis(buildMessage(1L, 1405970352, 2L)));
+        assertEquals(145028289000L, parser.extractTimestampMillis(buildMessage(1L, 145028289, 2L)));
+    }
+
+    @Test
+    public void testExtractTimestampThree() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestampThree");
+        Mockito.when(mConfig.getMessageTimestampId()).thenReturn(6);
+        Mockito.when(mConfig.getMessageTimestampType()).thenReturn("i64");
+
+        ThriftMessageParser parser = new ThriftMessageParser(mConfig);
+
+        assertEquals(1405970352000L, parser.extractTimestampMillis(buildMessage(1L, 2, 1405970352L)));
+        assertEquals(1405970352123L, parser.extractTimestampMillis(buildMessage(1L, 2, 1405970352123L)));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testAttemptExtractInvalidField() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("requiredField");
+        Mockito.when(mConfig.getMessageTimestampId()).thenReturn(2);
+        Mockito.when(mConfig.getMessageTimestampType()).thenReturn("i64");
+
+        ThriftMessageParser parser = new ThriftMessageParser(mConfig);
+
+        parser.extractTimestampMillis(buildMessage(1L, 2, 3L));
+    }
+
+}

--- a/src/test/thrift/unittest.thrift
+++ b/src/test/thrift/unittest.thrift
@@ -1,0 +1,18 @@
+/* Simple thrift message used in Secor unit testing */
+
+namespace java com.pinterest.secor.thrift
+
+enum UnitTestEnum {
+    SOME_VALUE = 0,
+    SOME_OTHER_VALUE = 1,
+}
+
+struct UnitTestMessage {
+    1: required i64 timestamp,
+    2: required string requiredField,
+    3: required i32 timestampTwo,
+    4: optional string optionalField,
+    5: optional UnitTestEnum enumField,
+    6: required i64 timestampThree
+}
+


### PR DESCRIPTION
This PR adds support for parsing dates from thrift messages from fields other than the first via a new parameter `message.timestamp.id`. For simplicity the field still needs to be at the top level of the thrift object. 

Also added a `message.timestamp.type` parameter which I've intentionally not mentioned in the documentation update -- if folks want to subject themselves to the 2038 problem like us, they'l have to dig for it.

If these config values are unset the behaviour defaults to the old behaviour of using the first field.