### PR TITLE
Kafka : add kafka consumer properties to allow offset migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Secor is distributed under [Apache License, Version 2.0](http://www.apache.org/l
   * [Yelp](http://www.yelp.com)
   * [VarageSale](http://www.varagesale.com)
   * [Skyscanner](http://www.skyscanner.net)
+  * [Nextperf](http://www.nextperf.com)
 
 ## Help
 

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,11 @@
                 <directory>src/main/config</directory>
             </resource>
         </resources>
+        <testResources>
+            <testResource>
+                <directory>src/test/config</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -139,6 +139,16 @@ kafka.seed.broker.port=9092
 # to as the chroot.
 kafka.zookeeper.path=/
 
+# Store offset in zookeeper and kafka consumer topic.
+# Only used if kafka.offsets.storage is set to "kafka"
+# http://kafka.apache.org/documentation.html#oldconsumerconfigs
+# Possible values: true or false
+kafka.dual.commit.enabled=true
+
+# Storage offset.
+# Possible values: "zookeeper" to read offset from zookeeper or "kafka" to read offset from kafka consumer topic
+kafka.offsets.storage=zookeeper
+
 # Secor generation is a version that should be incremented during non-backwards-compabile
 # Secor releases. Generation number is one of the components of generated log file names.
 # Generation number makes sure that outputs of different Secor versions are isolated.

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -117,6 +117,14 @@ public class SecorConfig {
         return getString("kafka.fetch.wait.max.ms");
     }
 
+    public String getDualCommitEnabled() {
+        return getString("kafka.dual.commit.enabled");
+    }
+
+    public String getOffsetsStorage() {
+        return getString("kafka.offsets.storage");
+    }
+
     public int getGeneration() {
         return getInt("secor.generation");
     }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -115,6 +115,10 @@ public class MessageReader {
         props.put("auto.offset.reset", "smallest");
         props.put("consumer.timeout.ms", Integer.toString(mConfig.getConsumerTimeoutMs()));
         props.put("consumer.id", IdUtil.getConsumerId());
+        // Properties required to upgrade from kafka 0.8.x to 0.9.x
+        props.put("dual.commit.enabled", mConfig.getDualCommitEnabled());
+        props.put("offsets.storage", mConfig.getOffsetsStorage());
+
         props.put("partition.assignment.strategy", mConfig.getPartitionAssignmentStrategy());
         if (mConfig.getRebalanceMaxRetries() != null &&
             !mConfig.getRebalanceMaxRetries().isEmpty()) {

--- a/src/test/config/secor.kafka.migration.test.properties
+++ b/src/test/config/secor.kafka.migration.test.properties
@@ -1,0 +1,6 @@
+# Store offset in zookeeper and kafka consumer topic
+kafka.dual.commit.enabled=false
+
+# Storage offset.
+# Possible value "zookeeper" to read offset from zookeeper or "kafka" to read offset from kafka consumer topic
+kafka.offsets.storage=kafka

--- a/src/test/java/com/pinterest/secor/common/SecorConfigTest.java
+++ b/src/test/java/com/pinterest/secor/common/SecorConfigTest.java
@@ -1,0 +1,34 @@
+package com.pinterest.secor.common;
+
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.Test;
+import java.net.URL;
+import static org.junit.Assert.*;
+
+public class SecorConfigTest {
+
+    @Test
+    public void config_should_read_migration_required_properties_default_values() throws ConfigurationException {
+
+        URL configFile = Thread.currentThread().getContextClassLoader().getResource("secor.common.properties");
+        PropertiesConfiguration properties = new PropertiesConfiguration(configFile);
+
+        SecorConfig secorConfig = new SecorConfig(properties);
+        assertEquals("true", secorConfig.getDualCommitEnabled());
+        assertEquals("zookeeper", secorConfig.getOffsetsStorage());
+    }
+
+    @Test
+    public void config_should_read_migration_required() throws ConfigurationException {
+
+        URL configFile = Thread.currentThread().getContextClassLoader().getResource("secor.kafka.migration.test.properties");
+        PropertiesConfiguration properties = new PropertiesConfiguration(configFile);
+
+        SecorConfig secorConfig = new SecorConfig(properties);
+        assertEquals("false", secorConfig.getDualCommitEnabled());
+        assertEquals("kafka", secorConfig.getOffsetsStorage());
+    }
+
+
+}


### PR DESCRIPTION
Hi,

With this pull request, you should be able to migrate offset from zookeeper to kafka consumer topic.
Then we can use Secor with kafka 0.9.0.  
[Kafka consumer documentation](http://kafka.apache.org/documentation.html#oldconsumerconfigs)

In the second commit, i just add my company to Secor users. We use it for several months in production.

I'm open to any suggestions :smile: 
