### PR TITLE
Logic to read timezone from config

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -250,3 +250,6 @@ secor.max.message.size.bytes=100000
 # Class that will manage uploads. Default is to use the hadoop
 # interface to S3.
 secor.upload.manager.class=com.pinterest.secor.uploader.HadoopS3UploadManager
+
+#Set below property to your timezone, and partitions in s3 will be created as per timezone provided
+#secor.parser.timezone=IST

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -252,4 +252,4 @@ secor.max.message.size.bytes=100000
 secor.upload.manager.class=com.pinterest.secor.uploader.HadoopS3UploadManager
 
 #Set below property to your timezone, and partitions in s3 will be created as per timezone provided
-#secor.parser.timezone=IST
+secor.parser.timezone=UTC

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -365,6 +365,10 @@ public class SecorConfig {
         return getInt("partitioner.finalizer.delay.seconds");
     }
 
+    public String getTimeZone(){
+        return getString("secor.parser.timezone");
+    }
+
     public boolean getBoolean(String name, boolean defaultValue) {
         return mProperties.getBoolean(name, defaultValue);
     }

--- a/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
@@ -54,11 +54,12 @@ public abstract class TimestampedMessageParser extends MessageParser implements 
         LOG.info("FinalizerDelaySeconds: {}", mFinalizerDelaySeconds);
 
         mDtFormatter = new SimpleDateFormat("yyyy-MM-dd");
-        mDtFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        TimeZone timeZone = config.getTimeZone() != null ? TimeZone.getTimeZone(config.getTimeZone()) : TimeZone.getTimeZone("UTC");
+        mDtFormatter.setTimeZone(timeZone);
         mHrFormatter = new SimpleDateFormat("HH");
-        mHrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mHrFormatter.setTimeZone(timeZone);
         mDtHrFormatter = new SimpleDateFormat("yyyy-MM-dd-HH");
-        mDtHrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mDtHrFormatter.setTimeZone(timeZone);
     }
 
     public abstract long extractTimestampMillis(final Message message) throws Exception;

--- a/src/main/java/com/pinterest/secor/tools/LogFileDeleter.java
+++ b/src/main/java/com/pinterest/secor/tools/LogFileDeleter.java
@@ -44,7 +44,8 @@ public class LogFileDeleter {
         }
         String[] consumerDirs = FileUtil.list(mConfig.getLocalPath());
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
-        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        TimeZone timeZone = mConfig.getTimeZone() != null ? TimeZone.getTimeZone(mConfig.getTimeZone()) : TimeZone.getTimeZone("UTC");
+        format.setTimeZone(timeZone);
         for (String consumerDir : consumerDirs) {
             long modificationTime = FileUtil.getModificationTimeMsRecursive(consumerDir);
             String modificationTimeStr = format.format(modificationTime);


### PR DESCRIPTION
TimestampedMessageParser has hardcoded UTC timezone. This change will read property from config file with default value as UTC which is handled in TimestampedMessageParser. 

This will help in creating partitions in s3 as per timezone provided. 