### PR TITLE
Logic to read timezone from config

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -250,3 +250,6 @@ secor.max.message.size.bytes=100000
 # Class that will manage uploads. Default is to use the hadoop
 # interface to S3.
 secor.upload.manager.class=com.pinterest.secor.uploader.HadoopS3UploadManager
+
+#Set below property to your timezone, and partitions in s3 will be created as per timezone provided
+secor.parser.timezone=UTC

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -367,8 +367,9 @@ public class SecorConfig {
         return getInt("partitioner.finalizer.delay.seconds");
     }
 
-    public TimeZone getTimeZone(){
-        return Strings.isNullOrEmpty(getString("secor.parser.timezone")) ?  TimeZone.getTimeZone("UTC") : TimeZone.getTimeZone(getString("secor.parser.timezone"));
+    public TimeZone getTimeZone() {
+        String timezone = getString("secor.parser.timezone");
+        return Strings.isNullOrEmpty(timezone) ? TimeZone.getTimeZone("UTC") : TimeZone.getTimeZone(timezone);
     }
 
     public boolean getBoolean(String name, boolean defaultValue) {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -16,12 +16,14 @@
  */
 package com.pinterest.secor.common;
 
+import com.google.api.client.repackaged.com.google.common.base.Strings;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang.StringUtils;
 
 import java.util.Map;
 import java.util.Properties;
+import java.util.TimeZone;
 
 /**
  * One-stop shop for Secor configuration options.
@@ -363,6 +365,10 @@ public class SecorConfig {
 
     public int getFinalizerDelaySeconds() {
         return getInt("partitioner.finalizer.delay.seconds");
+    }
+
+    public TimeZone getTimeZone(){
+        return Strings.isNullOrEmpty(getString("secor.parser.timezone")) ?  TimeZone.getTimeZone("UTC") : TimeZone.getTimeZone(getString("secor.parser.timezone"));
     }
 
     public boolean getBoolean(String name, boolean defaultValue) {

--- a/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
@@ -18,14 +18,12 @@ package com.pinterest.secor.parser;
 
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.message.Message;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.TimeZone;
+import java.util.List;
 
 public abstract class TimestampedMessageParser extends MessageParser implements Partitioner {
 
@@ -54,11 +52,11 @@ public abstract class TimestampedMessageParser extends MessageParser implements 
         LOG.info("FinalizerDelaySeconds: {}", mFinalizerDelaySeconds);
 
         mDtFormatter = new SimpleDateFormat("yyyy-MM-dd");
-        mDtFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mDtFormatter.setTimeZone(config.getTimeZone());
         mHrFormatter = new SimpleDateFormat("HH");
-        mHrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mHrFormatter.setTimeZone(config.getTimeZone());
         mDtHrFormatter = new SimpleDateFormat("yyyy-MM-dd-HH");
-        mDtHrFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        mDtHrFormatter.setTimeZone(config.getTimeZone());
     }
 
     public abstract long extractTimestampMillis(final Message message) throws Exception;

--- a/src/main/java/com/pinterest/secor/tools/LogFileDeleter.java
+++ b/src/main/java/com/pinterest/secor/tools/LogFileDeleter.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
-import java.util.TimeZone;
 
 /**
  * Log file deleter removes message old log files stored locally.
@@ -44,7 +43,7 @@ public class LogFileDeleter {
         }
         String[] consumerDirs = FileUtil.list(mConfig.getLocalPath());
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
-        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        format.setTimeZone(mConfig.getTimeZone());
         for (String consumerDir : consumerDirs) {
             long modificationTime = FileUtil.getModificationTimeMsRecursive(consumerDir);
             String modificationTimeStr = format.format(modificationTime);

--- a/src/test/java/com/pinterest/secor/parser/JsonMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/JsonMessageParserTest.java
@@ -16,11 +16,8 @@
  */
 package com.pinterest.secor.parser;
 
-import com.pinterest.secor.common.*;
+import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.message.Message;
-
-import java.util.Arrays;
-import java.util.List;
 import junit.framework.TestCase;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,6 +25,9 @@ import org.mockito.Mockito;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TimeZone;
 
 @RunWith(PowerMockRunner.class)
 public class JsonMessageParserTest extends TestCase {
@@ -43,6 +43,7 @@ public class JsonMessageParserTest extends TestCase {
         mConfig = Mockito.mock(SecorConfig.class);
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
         Mockito.when(mConfig.getFinalizerDelaySeconds()).thenReturn(3600);
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
 
         byte messageWithSecondsTimestamp[] =
                 "{\"timestamp\":\"1405911096\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
@@ -106,12 +107,49 @@ public class JsonMessageParserTest extends TestCase {
     }
 
     @Test
+    public void testExtractPartitionsForUTCDefaultTimezone() throws Exception {
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
+        JsonMessageParser jsonMessageParser = new JsonMessageParser(mConfig);
+
+        String expectedPartition = "dt=2014-07-21";
+
+        String resultSeconds[] = jsonMessageParser.extractPartitions(mMessageWithSecondsTimestamp);
+        assertEquals(1, resultSeconds.length);
+        assertEquals(expectedPartition, resultSeconds[0]);
+
+        String resultMillis[] = jsonMessageParser.extractPartitions(mMessageWithMillisTimestamp);
+        assertEquals(1, resultMillis.length);
+        assertEquals(expectedPartition, resultMillis[0]);
+    }
+
+
+    @Test
     public void testExtractHourlyPartitions() throws Exception {
         Mockito.when(TimestampedMessageParser.usingHourly(mConfig)).thenReturn(true);
         JsonMessageParser jsonMessageParser = new JsonMessageParser(mConfig);
 
         String expectedDtPartition = "dt=2014-07-21";
         String expectedHrPartition = "hr=02";
+
+        String resultSeconds[] = jsonMessageParser.extractPartitions(mMessageWithSecondsTimestamp);
+        assertEquals(2, resultSeconds.length);
+        assertEquals(expectedDtPartition, resultSeconds[0]);
+        assertEquals(expectedHrPartition, resultSeconds[1]);
+
+        String resultMillis[] = jsonMessageParser.extractPartitions(mMessageWithMillisTimestamp);
+        assertEquals(2, resultMillis.length);
+        assertEquals(expectedDtPartition, resultMillis[0]);
+        assertEquals(expectedHrPartition, resultMillis[1]);
+    }
+
+    @Test
+    public void testExtractHourlyPartitionsForNonUTCTimezone() throws Exception {
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("IST"));
+        Mockito.when(TimestampedMessageParser.usingHourly(mConfig)).thenReturn(true);
+        JsonMessageParser jsonMessageParser = new JsonMessageParser(mConfig);
+
+        String expectedDtPartition = "dt=2014-07-21";
+        String expectedHrPartition = "hr=08";
 
         String resultSeconds[] = jsonMessageParser.extractPartitions(mMessageWithSecondsTimestamp);
         assertEquals(2, resultSeconds.length);

--- a/src/test/java/com/pinterest/secor/parser/MessagePackParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/MessagePackParserTest.java
@@ -28,6 +28,7 @@ import org.msgpack.jackson.dataformat.MessagePackFactory;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.HashMap;
+import java.util.TimeZone;
 
 @RunWith(PowerMockRunner.class)
 public class MessagePackParserTest extends TestCase {
@@ -43,6 +44,7 @@ public class MessagePackParserTest extends TestCase {
     public void setUp() throws Exception {
         SecorConfig mConfig = Mockito.mock(SecorConfig.class);
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("ts");
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
         mMessagePackParser = new MessagePackParser(mConfig);
         mObjectMapper = new ObjectMapper(new MessagePackFactory());
 


### PR DESCRIPTION
Accidentally deleted old merge request. 
1. Timezone reading has moved to config file. 
2. as per Timezone api doc,

      : TimeZone.getTimeZone(<id> )  will return the specified TimeZone, or the GMT zone if the given ID cannot be understood.