### PR TITLE
Fix a regresion on JsonMessageParser where the timestamp separator is…

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/MessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/MessageParser.java
@@ -41,7 +41,10 @@ public abstract class MessageParser {
 
     public MessageParser(SecorConfig config) {
         mConfig = config;
-        if (mConfig.getMessageTimestampName() != null && mConfig.getMessageTimestampNameSeparator() != null) {
+        if (mConfig.getMessageTimestampName() != null &&
+            !mConfig.getMessageTimestampName().isEmpty() &&
+            mConfig.getMessageTimestampNameSeparator() != null &&
+            !mConfig.getMessageTimestampNameSeparator().isEmpty()) {
             String separatorPattern = Pattern.quote(mConfig.getMessageTimestampNameSeparator());
             mNestedFields = mConfig.getMessageTimestampName().split(separatorPattern);
         }


### PR DESCRIPTION
… checked against null, not empty string

This was a recent checkin by open source community, looks like the check is not complete (only checked against null, not empty string), this caused the timestamp field cannot be retrieved.