### PR TITLE
Tighten the check on missing timestamp field for json message

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -246,6 +246,11 @@ message.timestamp.type=i64
 # Should be used when there is no timestamp in a Long format. Also ignore time zones.
 message.timestamp.input.pattern=
 
+# whether timestamp field is required, it should always be required.  But
+# for historical reason, we didn't enforce this check, there might exist some
+# installations with messages missing timestamp field
+message.timestamp.required=true
+
 # To enable compression, set this to a valid compression codec implementing 
 # org.apache.hadoop.io.compress.CompressionCodec interface, such as 
 # 'org.apache.hadoop.io.compress.GzipCodec'.

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -322,6 +322,10 @@ public class SecorConfig {
         return getString("message.timestamp.input.pattern");
     }
 
+    public boolean isMessageTimestampRequired() {
+        return mProperties.getBoolean("message.timestamp.required");
+    }
+
     public int getFinalizerLookbackPeriods() {
         return getInt("secor.finalizer.lookback.periods", 10);
     }

--- a/src/main/java/com/pinterest/secor/parser/JsonMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/JsonMessageParser.java
@@ -26,8 +26,11 @@ import net.minidev.json.JSONValue;
  * from JSON data and partitions data by date.
  */
 public class JsonMessageParser extends TimestampedMessageParser {
+    private final boolean m_timestampRequired;
+
     public JsonMessageParser(SecorConfig config) {
         super(config);
+        m_timestampRequired = config.isMessageTimestampRequired();
     }
 
     @Override
@@ -38,6 +41,8 @@ public class JsonMessageParser extends TimestampedMessageParser {
             if (fieldValue != null) {
                 return toMillis(Double.valueOf(fieldValue.toString()).longValue());
             }
+        } else if (m_timestampRequired) {
+            throw new RuntimeException("Missing timestamp field for message: " + message);
         }
         return 0;
     }


### PR DESCRIPTION
We had a regresion last week when someone made a checkin which didn't extract the correct timestamp field which makes the json message passing through with timestamp information extracted correctly.

Tighten the check to make sure the timestamp field is always required for json messages.

Make this check dependdent on config property: message.timestamp.required, just in case some installations had broken messages but they don't want to change the behavior.