### PR TITLE
Fix for custom compression codec

### DIFF
--- a/src/main/java/com/pinterest/secor/util/CompressionUtil.java
+++ b/src/main/java/com/pinterest/secor/util/CompressionUtil.java
@@ -16,6 +16,9 @@
  */
 package com.pinterest.secor.util;
 
+import java.util.Collections;
+import java.util.LinkedList;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
@@ -31,8 +34,10 @@ public class CompressionUtil {
 
     public static CompressionCodec createCompressionCodec(String className)
             throws Exception {
+        Configuration configuration = new Configuration();
+        CompressionCodecFactory.setCodecClasses(configuration,new LinkedList<Class>(Collections.singletonList(Class.forName(className))));
         CompressionCodecFactory ccf = new CompressionCodecFactory(
-                new Configuration());
+                configuration);
         return ccf.getCodecByClassName(className);
     }
 }


### PR DESCRIPTION
I tried to use lzo compression with secor but it always failed with null pointer exception because it did not find the set codec even if it was on the classpath.
I checked it and it is because it was not added to the CompressionCodecFactory's configuration. 
Due to this ccf.getCodecByClassName won't give back the set compression codec (except if it is gzip which is set by default) as it won't be in the hashmap (codecsByName) where it tries to find the set codec.

With the modification I did in the pull request lzo compression worked fine for us.