### PR TITLE
fix file extension

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
+++ b/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
@@ -54,7 +54,7 @@ public class PartitionFinalizer {
         mMessageParser = (TimestampedMessageParser) ReflectionUtil.createMessageParser(
           mConfig.getMessageParserClass(), mConfig);
         mQuboleClient = new QuboleClient(mConfig);
-        if (mConfig.getFileExtension() != null) {
+        if (mConfig.getFileExtension() != null && !mConfig.getFileExtension().isEmpty()) {
             mFileExtension = mConfig.getFileExtension();
         } else if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
             CompressionCodec codec = CompressionUtil.createCompressionCodec(mConfig.getCompressionCodec());

--- a/src/main/java/com/pinterest/secor/writer/MessageWriter.java
+++ b/src/main/java/com/pinterest/secor/writer/MessageWriter.java
@@ -55,7 +55,9 @@ public class MessageWriter {
         mConfig = config;
         mOffsetTracker = offsetTracker;
         mFileRegistry = fileRegistry;
-        if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
+        if (mConfig.getFileExtension() != null && !mConfig.getFileExtension().isEmpty()) {
+            mFileExtension = mConfig.getFileExtension();
+        } else if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
             mCodec = CompressionUtil.createCompressionCodec(mConfig.getCompressionCodec());
             mFileExtension = mCodec.getDefaultExtension();
         } else {


### PR DESCRIPTION
Hi,

This commit backport the file extension in MessageWriter class.

I test with the following properties:
```
secor.file.extension=.parquet 
secor.upload.manager.class=com.pinterest.secor.uploader.S3UploadManager
```
Without this patch, the file uploaded in S3 have no extension.
I have just test this fix to have the right extension.

You can take it or throw it ;-)

Enjoy :smiling_imp: 
