### PR TITLE
Fix a log statement in KafkaClient

### DIFF
--- a/src/main/java/com/pinterest/secor/common/KafkaClient.java
+++ b/src/main/java/com/pinterest/secor/common/KafkaClient.java
@@ -113,7 +113,7 @@ public class KafkaClient {
 
     private Message getMessage(TopicPartition topicPartition, long offset,
                                SimpleConsumer consumer) {
-        LOG.debug("fetching message topic {} partition {} offset ",
+        LOG.debug("fetching message topic {} partition {} offset {}",
                 topicPartition.getTopic(), topicPartition.getPartition(), offset);
         final int MAX_MESSAGE_SIZE_BYTES = mConfig.getMaxMessageSizeBytes();
         final String clientName = getClientName(topicPartition);


### PR DESCRIPTION
The log statement I edited attempted to print the offset it was requested, but it is missing some curly braces. A simple fix.