### PR TITLE
making SecorConfig method public & use timezone from config for dateparser

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -416,32 +416,32 @@ public class SecorConfig {
         return mProperties.getBoolean(name);
     }
 
-    private void checkProperty(String name) {
+    public void checkProperty(String name) {
         if (!mProperties.containsKey(name)) {
             throw new RuntimeException("Failed to find required configuration option '" +
                                        name + "'.");
         }
     }
 
-    private String getString(String name) {
+    public String getString(String name) {
         checkProperty(name);
         return mProperties.getString(name);
     }
 
-    private int getInt(String name) {
+    public int getInt(String name) {
         checkProperty(name);
         return mProperties.getInt(name);
     }
 
-    private int getInt(String name, int defaultValue) {
+    public int getInt(String name, int defaultValue) {
         return mProperties.getInt(name, defaultValue);
     }
 
-    private long getLong(String name) {
+    public long getLong(String name) {
         return mProperties.getLong(name);
     }
 
-    private String[] getStringArray(String name) {
+    public String[] getStringArray(String name) {
         return mProperties.getStringArray(name);
     }
 }

--- a/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
@@ -42,9 +42,9 @@ public class DateMessageParser extends MessageParser {
     private static final Logger LOG = LoggerFactory.getLogger(DateMessageParser.class);
     protected static final String defaultDate = "dt=1970-01-01";
     protected static final String defaultFormatter = "yyyy-MM-dd";
-    SimpleDateFormat outputFormatter = new SimpleDateFormat(defaultFormatter);
-    Object inputPattern;
-    SimpleDateFormat inputFormatter;
+    protected SimpleDateFormat outputFormatter = new SimpleDateFormat(defaultFormatter);
+    protected Object inputPattern;
+    protected SimpleDateFormat inputFormatter;
     
     public DateMessageParser(SecorConfig config) {
         super(config);

--- a/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
@@ -18,15 +18,16 @@ package com.pinterest.secor.parser;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
-import net.minidev.json.JSONObject;
-import net.minidev.json.JSONValue;
+import java.util.TimeZone;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.message.Message;
+
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
 
 /**
  * DateMessageParser extracts timestamp field (specified by 'message.timestamp.name') 
@@ -41,9 +42,17 @@ public class DateMessageParser extends MessageParser {
     private static final Logger LOG = LoggerFactory.getLogger(DateMessageParser.class);
     protected static final String defaultDate = "dt=1970-01-01";
     protected static final String defaultFormatter = "yyyy-MM-dd";
-
+    SimpleDateFormat outputFormatter = new SimpleDateFormat(defaultFormatter);
+    Object inputPattern;
+    SimpleDateFormat inputFormatter;
+    
     public DateMessageParser(SecorConfig config) {
         super(config);
+        TimeZone timeZone = config.getTimeZone();
+        inputPattern = mConfig.getMessageTimestampInputPattern();
+        inputFormatter = new SimpleDateFormat(inputPattern.toString());
+        inputFormatter.setTimeZone(timeZone);
+        outputFormatter.setTimeZone(timeZone);
     }
 
     @Override
@@ -53,11 +62,8 @@ public class DateMessageParser extends MessageParser {
 
         if (jsonObject != null) {
             Object fieldValue = getJsonFieldValue(jsonObject);
-            Object inputPattern = mConfig.getMessageTimestampInputPattern();
             if (fieldValue != null && inputPattern != null) {
                 try {
-                    SimpleDateFormat inputFormatter = new SimpleDateFormat(inputPattern.toString());
-                    SimpleDateFormat outputFormatter = new SimpleDateFormat(defaultFormatter);
                     Date dateFormat = inputFormatter.parse(fieldValue.toString());
                     result[0] = "dt=" + outputFormatter.format(dateFormat);
                     return result;

--- a/src/main/java/com/pinterest/secor/parser/Iso8601MessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/Iso8601MessageParser.java
@@ -43,6 +43,7 @@ public class Iso8601MessageParser extends MessageParser {
 
     public Iso8601MessageParser(SecorConfig config) {
         super(config);
+        outputFormatter.setTimeZone(config.getTimeZone());
     }
 
     @Override

--- a/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
@@ -18,6 +18,8 @@ package com.pinterest.secor.parser;
 
 import junit.framework.TestCase;
 
+import java.util.TimeZone;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -42,6 +44,7 @@ public class DateMessageParserTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         mConfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
         
         byte format1[] = "{\"timestamp\":\"2014-07-30 10:53:20\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
                 .getBytes("UTF-8");

--- a/src/test/java/com/pinterest/secor/parser/Iso8601ParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/Iso8601ParserTest.java
@@ -18,6 +18,8 @@ package com.pinterest.secor.parser;
 
 import junit.framework.TestCase;
 
+import java.util.TimeZone;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -44,6 +46,8 @@ public class Iso8601ParserTest extends TestCase {
     @Override
     public void setUp() throws Exception {
         mConfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
+        
         byte format1[] = "{\"timestamp\":\"2014-07-30T10:53:20.001Z\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
                 .getBytes("UTF-8");
         mFormat1 = new Message("test", 0, 0, null, format1);
@@ -76,7 +80,6 @@ public class Iso8601ParserTest extends TestCase {
     @Test
     public void testExtractDate() throws Exception {
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
-
         assertEquals("dt=2014-07-30", new Iso8601MessageParser(mConfig).extractPartitions(mFormat1)[0]);
         assertEquals("dt=2014-07-29", new Iso8601MessageParser(mConfig).extractPartitions(mFormat2)[0]);
         assertEquals("dt=2001-07-04", new Iso8601MessageParser(mConfig).extractPartitions(mFormat3)[0]);


### PR DESCRIPTION
Hi,

While I was trying to build project one of jUnit test case for Iso8601ParserTest.java class was failing. My timezone is GMT+05:30 and when it was processing one "timestamp":"2016-03-02T18:36:14+00:00" it is converting this into "2016-03-03T00:06:14+00:00"(As per GMT). I have modified the code based on configure timezone.

Please check and let me know in case of more clarification.

Thanks,
Lovenish
