### PR TITLE
Reorder handling of codec and file-extension

### DIFF
--- a/src/main/java/com/pinterest/secor/writer/MessageWriter.java
+++ b/src/main/java/com/pinterest/secor/writer/MessageWriter.java
@@ -55,14 +55,16 @@ public class MessageWriter {
         mConfig = config;
         mOffsetTracker = offsetTracker;
         mFileRegistry = fileRegistry;
-        if (mConfig.getFileExtension() != null && !mConfig.getFileExtension().isEmpty()) {
-            mFileExtension = mConfig.getFileExtension();
-        } else if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
+        if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
             mCodec = CompressionUtil.createCompressionCodec(mConfig.getCompressionCodec());
             mFileExtension = mCodec.getDefaultExtension();
-        } else {
+        }
+        if (mConfig.getFileExtension() != null && !mConfig.getFileExtension().isEmpty()) {
+            mFileExtension = mConfig.getFileExtension();
+        } else if (mFileExtension == null){
             mFileExtension = "";
         }
+        
         mLocalPrefix = mConfig.getLocalPath() + '/' + IdUtil.getLocalMessageDir();
         mGeneration = mConfig.getGeneration();
     }


### PR DESCRIPTION
In the current state, if the config defines both compression codec and file extension, the compression codec is not applied. 
Setting a compression codec should not rely on file extension to NOT be set. Especially since the comments in the config file state "gz" as an example for `secor.file.extension`