### PR TITLE
Expose existing Log file writers

### DIFF
--- a/src/main/java/com/pinterest/secor/common/FileRegistry.java
+++ b/src/main/java/com/pinterest/secor/common/FileRegistry.java
@@ -76,6 +76,16 @@ public class FileRegistry {
     }
 
     /**
+     * Retrieve an existing writer for a given path.
+     * @param path The path to retrieve writer for.
+     * @return Writer for a given path or null if no writer has been created yet.
+     */
+    public FileWriter getWriter(LogFilePath path)
+            throws Exception {
+        return mWriters.get(path);
+    }
+
+    /**
      * Retrieve a writer for a given path or create a new one if it does not exist.
      * @param path The path to retrieve writer for.
      * @param codec Optional compression codec.

--- a/src/test/java/com/pinterest/secor/common/FileRegistryTest.java
+++ b/src/test/java/com/pinterest/secor/common/FileRegistryTest.java
@@ -64,7 +64,7 @@ public class FileRegistryTest extends TestCase {
         mLogFilePathGz = new LogFilePath("/some_parent_dir", PATH_GZ);
     }
 
-    private void createWriter() throws Exception {
+    private FileWriter createWriter() throws Exception {
         PowerMockito.mockStatic(FileUtil.class);
 
         PowerMockito.mockStatic(ReflectionUtil.class);
@@ -82,6 +82,8 @@ public class FileRegistryTest extends TestCase {
         FileWriter createdWriter = mRegistry.getOrCreateWriter(
                 mLogFilePath, null);
         assertTrue(createdWriter == writer);
+
+        return writer;
     }
 
     public void testGetOrCreateWriter() throws Exception {
@@ -112,6 +114,18 @@ public class FileRegistryTest extends TestCase {
                 .getPaths(topicPartition);
         assertEquals(1, logFilePaths.size());
         assertTrue(logFilePaths.contains(mLogFilePath));
+    }
+
+    public void testGetWriterShowBeNullForNewFilePaths() throws Exception {
+        assertNull(mRegistry.getWriter(mLogFilePath));
+    }
+
+    public void testGetWriterShowBeNotNull() throws Exception {
+        FileWriter createdWriter = createWriter();
+
+        FileWriter writer = mRegistry.getWriter(mLogFilePath);
+        assertNotNull(writer);
+        assertEquals(createdWriter, writer);
     }
 
     private void createCompressedWriter() throws Exception {


### PR DESCRIPTION
Make the existing writers of the log files accessible from the outside
as they may be needed for custom uploaders.