### PR TITLE
Update partition finalizer to use full path prefix instead of just the prefix

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
+++ b/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
@@ -103,7 +103,7 @@ public class PartitionFinalizer {
                 mConfig.getGeneration(), 0, 0, mFileExtension);
 
             if (FileUtil.s3PathPrefixIsAltered(logFilePath.getLogFilePath(), mConfig)) {
-                logFilePath = logFilePath.withPrefix(FileUtil.getS3AlternativePathPrefix(mConfig));
+                logFilePath = logFilePath.withPrefix(FileUtil.getS3AlternativePrefix(mConfig));
             }
 
             String logFileDir = logFilePath.getLogFileDir();
@@ -182,7 +182,7 @@ public class PartitionFinalizer {
                 mConfig.getGeneration(), 0, 0, mFileExtension);
 
             if (FileUtil.s3PathPrefixIsAltered(logFilePath.getLogFilePath(), mConfig)) {
-                logFilePath = logFilePath.withPrefix(FileUtil.getS3AlternativePathPrefix(mConfig));
+                logFilePath = logFilePath.withPrefix(FileUtil.getS3AlternativePrefix(mConfig));
                 LOG.info("Will finalize alternative s3 logFilePath {}", logFilePath);
             }
 


### PR DESCRIPTION
This change adjusts the path prefix in the partition finalizer to include the uri and bucket, rather than the prefix alone.