### PR TITLE
Removed absent parameters

### DIFF
--- a/src/main/java/com/pinterest/secor/consumer/Consumer.java
+++ b/src/main/java/com/pinterest/secor/consumer/Consumer.java
@@ -167,9 +167,7 @@ public class Consumer extends Thread {
     /**
      * Helper to get the offset tracker (used in tests)
      * 
-     * @param topic
-     * @param partition
-     * @return
+     * @return the offset tracker
      */
     public OffsetTracker getOffsetTracker() {
         return this.mOffsetTracker;


### PR DESCRIPTION
This inspection points out unresolved references inside javadoc