### PR TITLE
Adding argument reading to LogVerifier

### DIFF
--- a/src/main/java/com/pinterest/secor/main/LogFileVerifierMain.java
+++ b/src/main/java/com/pinterest/secor/main/LogFileVerifierMain.java
@@ -49,11 +49,13 @@ public class LogFileVerifierMain {
                .create("t"));
         options.addOption(OptionBuilder.withLongOpt("start_offset")
                .withDescription("offset identifying the first set of files to check")
+               .hasArg()
                .withArgName("<offset>")
                .withType(Long.class)
                .create("s"));
         options.addOption(OptionBuilder.withLongOpt("end_offset")
                .withDescription("offset identifying the last set of files to check")
+               .hasArg()
                .withArgName("<offset>")
                .withType(Long.class)
                .create("e"));


### PR DESCRIPTION
It was failing with NullPointerException because it wasn't looking for an argument here. I can add a test too if required but this seemed obvious enough.

