### PR TITLE
Uploads at minute mark for selected topics

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -307,3 +307,9 @@ secor.s3.alter.path.date=
 
 # An alternative S3 path for secor to upload files to
 secor.s3.alternative.path=
+
+# Topics to upload at a fixed minute mark
+secor.kafka.upload_at_minute_mark.topic_filter=
+
+# What the minute mark is. This isn't triggered unless the topic name matches
+secor.upload.minute_mark=0

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -197,6 +197,10 @@ public class SecorConfig {
         return getString("secor.kafka.topic_blacklist");
     }
 
+    public String getKafkaTopicUploadAtMinuteMarkFilter() { return getString("secor.kafka.upload_at_minute_mark.topic_filter");}
+
+    public int getUploadMinuteMark(){ return getInt("secor.upload.minute_mark");}
+
     public String getKafkaGroup() {
         return getString("secor.kafka.group");
     }

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -27,6 +27,7 @@ import com.pinterest.secor.util.ReflectionUtil;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.io.compress.CompressionCodec;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -181,12 +182,31 @@ public class Uploader {
         }
     }
 
+    /***
+     * If the topic is in the list of topics to upload at a specific time. For example at a minute mark.
+     * @param topicPartition
+     * @return
+     * @throws Exception
+     */
+    private boolean isRequiredToUploadAtTime(TopicPartition topicPartition) throws Exception{
+        final String topic = topicPartition.getTopic();
+        final String topicFilter = mConfig.getKafkaTopicUploadAtMinuteMarkFilter();
+        if (topicFilter == null || topicFilter.isEmpty()){ return false; }
+        if (topic.matches(topicFilter)){
+            if (DateTime.now().minuteOfHour().get() == mConfig.getUploadMinuteMark()){
+               return true;
+            }
+        }
+        return false;
+    }
+
     private void checkTopicPartition(TopicPartition topicPartition) throws Exception {
         final long size = mFileRegistry.getSize(topicPartition);
         final long modificationAgeSec = mFileRegistry.getModificationAgeSec(topicPartition);
         LOG.debug("size: " + size + " modificationAge: " + modificationAgeSec);
         if (size >= mConfig.getMaxFileSizeBytes() ||
-                modificationAgeSec >= mConfig.getMaxFileAgeSeconds()) {
+                modificationAgeSec >= mConfig.getMaxFileAgeSeconds() ||
+                isRequiredToUploadAtTime(topicPartition)) {
             long newOffsetCount = mZookeeperConnector.getCommittedOffsetCount(topicPartition);
             long oldOffsetCount = mOffsetTracker.setCommittedOffsetCount(topicPartition,
                     newOffsetCount);

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -47,6 +47,7 @@ public class Uploader {
     private FileRegistry mFileRegistry;
     private ZookeeperConnector mZookeeperConnector;
     private UploadManager mUploadManager;
+    private String mTopicFilter;
 
 
     /**
@@ -72,6 +73,8 @@ public class Uploader {
         mFileRegistry = fileRegistry;
         mUploadManager = uploadManager;
         mZookeeperConnector = zookeeperConnector;
+        mTopicFilter = mConfig.getKafkaTopicUploadAtMinuteMarkFilter();
+
     }
 
     private void uploadFiles(TopicPartition topicPartition) throws Exception {
@@ -190,9 +193,10 @@ public class Uploader {
      */
     private boolean isRequiredToUploadAtTime(TopicPartition topicPartition) throws Exception{
         final String topic = topicPartition.getTopic();
-        final String topicFilter = mConfig.getKafkaTopicUploadAtMinuteMarkFilter();
-        if (topicFilter == null || topicFilter.isEmpty()){ return false; }
-        if (topic.matches(topicFilter)){
+        if (mTopicFilter == null || mTopicFilter.isEmpty()){
+            return false;
+        }
+        if (topic.matches(mTopicFilter)){
             if (DateTime.now().minuteOfHour().get() == mConfig.getUploadMinuteMark()){
                return true;
             }

--- a/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
+++ b/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
@@ -26,8 +26,11 @@ import com.pinterest.secor.util.IdUtil;
 import junit.framework.TestCase;
 
 import org.apache.hadoop.io.compress.CompressionCodec;
+import org.joda.time.DateTime;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.internal.exceptions.ExceptionIncludingMockitoWarnings;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
@@ -43,7 +46,7 @@ import java.util.HashSet;
  * @author Pawel Garbacki (pawel@pinterest.com)
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ FileUtil.class, IdUtil.class })
+@PrepareForTest({ FileUtil.class, IdUtil.class , DateTime.class})
 public class UploaderTest extends TestCase {
     private static class TestUploader extends Uploader {
         private FileReader mReader;
@@ -109,6 +112,44 @@ public class UploaderTest extends TestCase {
                 mZookeeperConnector);
     }
 
+    public void testUploadAtTime() throws Exception {
+        final int minuteUploadMark = 1;
+
+        PowerMockito.mockStatic(DateTime.class);
+        PowerMockito.when(DateTime.now()).thenReturn(new DateTime(2016,7,27,0,minuteUploadMark,0));
+        Mockito.when(mConfig.getUploadMinuteMark()).thenReturn(minuteUploadMark);
+        Mockito.when(mConfig.getKafkaTopicFilter()).thenReturn("some_topic");
+
+        Mockito.when(mConfig.getCloudService()).thenReturn("S3");
+        Mockito.when(mConfig.getS3Bucket()).thenReturn("some_bucket");
+        Mockito.when(mConfig.getS3Path()).thenReturn("some_s3_parent_dir");
+
+        HashSet<LogFilePath> logFilePaths = new HashSet<LogFilePath>();
+        logFilePaths.add(mLogFilePath);
+        Mockito.when(mFileRegistry.getPaths(mTopicPartition)).thenReturn(
+                logFilePaths);
+
+        PowerMockito.mockStatic(FileUtil.class);
+        Mockito.when(FileUtil.getPrefix("some_topic", mConfig)).
+                thenReturn("s3a://some_bucket/some_s3_parent_dir");
+        mUploader.applyPolicy();
+
+        final String lockPath = "/secor/locks/some_topic/0";
+        Mockito.verify(mZookeeperConnector).lock(lockPath);
+        PowerMockito.verifyStatic();
+        FileUtil.moveToCloud(
+                "/some_parent_dir/some_topic/some_partition/some_other_partition/"
+                        + "10_0_00000000000000000010",
+                "s3a://some_bucket/some_s3_parent_dir/some_topic/some_partition/"
+                        + "some_other_partition/10_0_00000000000000000010");
+        Mockito.verify(mFileRegistry).deleteTopicPartition(mTopicPartition);
+        Mockito.verify(mZookeeperConnector).setCommittedOffsetCount(
+                mTopicPartition, 1L);
+        Mockito.verify(mOffsetTracker).setCommittedOffsetCount(mTopicPartition,
+                1L);
+        Mockito.verify(mZookeeperConnector).unlock(lockPath);
+    }
+
     public void testUploadFiles() throws Exception {
         Mockito.when(
                 mZookeeperConnector.getCommittedOffsetCount(mTopicPartition))
@@ -124,6 +165,7 @@ public class UploaderTest extends TestCase {
         Mockito.when(
                 mOffsetTracker.getTrueCommittedOffsetCount(mTopicPartition))
                 .thenReturn(11L);
+
 
         Mockito.when(mConfig.getCloudService()).thenReturn("S3");
         Mockito.when(mConfig.getS3Bucket()).thenReturn("some_bucket");


### PR DESCRIPTION
If secor is started at something other than the top of the hour mark or some other desired time, I've found that it doesn't upload at the desired times. We have operational requirements on some topics to have data at or close to the top of the hour mark. So this feature enables to start/restart secor whenever and be able to upload the files upto that point.

- This is restricted to particular topic filters that may require files
to be available at particular time for batch jobs
- Adds two configs:
  - secor.kafka.upload_at_minute_mark.topic_filter
  - secor.upload.minute_mark