### PR TITLE
File Coalescing: Enhance FileRegistry and LogFilePath to have the capability of specifying multiple partitions

### DIFF
--- a/src/main/java/com/pinterest/secor/common/FileRegistry.java
+++ b/src/main/java/com/pinterest/secor/common/FileRegistry.java
@@ -38,13 +38,13 @@ public class FileRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(FileRegistry.class);
 
     private final SecorConfig mConfig;
-    private HashMap<TopicPartition, HashSet<LogFilePath>> mFiles;
+    private HashMap<TopicPartitionGroup, HashSet<LogFilePath>> mFiles;
     private HashMap<LogFilePath, FileWriter> mWriters;
     private HashMap<LogFilePath, Long> mCreationTimes;
 
     public FileRegistry(SecorConfig mConfig) {
         this.mConfig = mConfig;
-        mFiles = new HashMap<TopicPartition, HashSet<LogFilePath>>();
+        mFiles = new HashMap<TopicPartitionGroup, HashSet<LogFilePath>>();
         mWriters = new HashMap<LogFilePath, FileWriter>();
         mCreationTimes = new HashMap<LogFilePath, Long>();
     }
@@ -54,12 +54,23 @@ public class FileRegistry {
      * @return Collection of all registered topic partitions.
      */
     public Collection<TopicPartition> getTopicPartitions() {
-        Set<TopicPartition> topicPartitions = mFiles.keySet();
-        if (topicPartitions == null) {
-            return new HashSet<TopicPartition>();
+        Collection<TopicPartitionGroup> topicPartitions = getTopicPartitionGroups();
+        Set<TopicPartition> tps = new HashSet<TopicPartition>();
+        if (topicPartitions != null) {
+            for (TopicPartitionGroup g : topicPartitions) {
+                tps.addAll(g.getTopicPartitions());
+            }
         }
-        // Return a copy of the collection to prevent the caller from modifying internals.
-        return new HashSet<TopicPartition>(topicPartitions);
+        return tps;
+    }
+
+    public Collection<TopicPartitionGroup> getTopicPartitionGroups() {
+        Set<TopicPartitionGroup> topicPartitions = mFiles.keySet();
+        Set<TopicPartitionGroup> tps = new HashSet<TopicPartitionGroup>();
+        if (topicPartitions != null) {
+            tps.addAll(topicPartitions);
+        }
+        return tps;
     }
 
     /**
@@ -68,7 +79,16 @@ public class FileRegistry {
      * @return Collection of file paths in the given topic partition.
      */
     public Collection<LogFilePath> getPaths(TopicPartition topicPartition) {
-        HashSet<LogFilePath> logFilePaths = mFiles.get(topicPartition);
+        return getPaths(new TopicPartitionGroup(topicPartition));
+    }
+
+    /**
+     * Get paths in a given topic partition.
+     * @param topicPartitionGroup The topic partition to retrieve paths for.
+     * @return Collection of file paths in the given topic partition.
+     */
+    public Collection<LogFilePath> getPaths(TopicPartitionGroup topicPartitionGroup) {
+        HashSet<LogFilePath> logFilePaths = mFiles.get(topicPartitionGroup);
         if (logFilePaths == null) {
             return new HashSet<LogFilePath>();
         }
@@ -99,8 +119,8 @@ public class FileRegistry {
             // Just in case.
             FileUtil.delete(path.getLogFilePath());
             FileUtil.delete(path.getLogFileCrcPath());
-            TopicPartition topicPartition = new TopicPartition(path.getTopic(),
-                    path.getKafkaPartition());
+            TopicPartitionGroup topicPartition = new TopicPartitionGroup(path.getTopic(),
+                    path.getKafkaPartitions());
             HashSet<LogFilePath> files = mFiles.get(topicPartition);
             if (files == null) {
                 files = new HashSet<LogFilePath>();
@@ -128,16 +148,16 @@ public class FileRegistry {
      * @throws IOException
      */
     public void deletePath(LogFilePath path) throws IOException {
-        TopicPartition topicPartition = new TopicPartition(path.getTopic(),
-                                                           path.getKafkaPartition());
+        TopicPartitionGroup topicPartition = new TopicPartitionGroup(path.getTopic(),
+                                                           path.getKafkaPartitions());
         HashSet<LogFilePath> paths = mFiles.get(topicPartition);
         paths.remove(path);
         if (paths.isEmpty()) {
             mFiles.remove(topicPartition);
             StatsUtil.clearLabel("secor.size." + topicPartition.getTopic() + "." +
-                                 topicPartition.getPartition());
+                                 topicPartition.getPartitions()[0]);
             StatsUtil.clearLabel("secor.modification_age_sec." + topicPartition.getTopic() + "." +
-                                 topicPartition.getPartition());
+                                 topicPartition.getPartitions()[0]);
         }
         deleteWriter(path);
         FileUtil.delete(path.getLogFilePath());
@@ -150,7 +170,11 @@ public class FileRegistry {
      * @throws IOException
      */
     public void deleteTopicPartition(TopicPartition topicPartition) throws IOException {
-        HashSet<LogFilePath> paths = mFiles.get(topicPartition);
+        deleteTopicPartitionGroup((new TopicPartitionGroup(topicPartition)));
+    }
+
+    public void deleteTopicPartitionGroup(TopicPartitionGroup topicPartitioGroup) throws IOException {
+        HashSet<LogFilePath> paths = mFiles.get(topicPartitioGroup);
         if (paths == null) {
             return;
         }
@@ -181,9 +205,14 @@ public class FileRegistry {
      * @param topicPartition The topic partition to remove the writers for.
      */
     public void deleteWriters(TopicPartition topicPartition) throws IOException {
-        HashSet<LogFilePath> paths = mFiles.get(topicPartition);
+        deleteWriters(new TopicPartitionGroup(topicPartition));
+    }
+
+    public void deleteWriters(TopicPartitionGroup topicPartitionGroup) throws IOException {
+        HashSet<LogFilePath> paths = mFiles.get(topicPartitionGroup);
         if (paths == null) {
-            LOG.warn("No paths found for topic {} partition {}", topicPartition.getTopic(), topicPartition.getPartition());
+            LOG.warn("No paths found for topic {} partition {}", topicPartitionGroup.getTopic(),
+                Arrays.toString(topicPartitionGroup.getPartitions()));
         } else {
             for (LogFilePath path : paths) {
                 deleteWriter(path);
@@ -199,7 +228,11 @@ public class FileRegistry {
      * @throws IOException
      */
     public long getSize(TopicPartition topicPartition) throws IOException {
-        Collection<LogFilePath> paths = getPaths(topicPartition);
+        return getSize(new TopicPartitionGroup(topicPartition));
+    }
+
+    public long getSize(TopicPartitionGroup topicPartitionGroup) throws IOException {
+        Collection<LogFilePath> paths = getPaths(topicPartitionGroup);
         long result = 0;
         for (LogFilePath path : paths) {
             FileWriter writer = mWriters.get(path);
@@ -207,8 +240,8 @@ public class FileRegistry {
                 result += writer.getLength();
             }
         }
-        StatsUtil.setLabel("secor.size." + topicPartition.getTopic() + "." +
-                           topicPartition.getPartition(), Long.toString(result));
+        StatsUtil.setLabel("secor.size." + topicPartitionGroup.getTopic() + "." +
+            Arrays.toString(topicPartitionGroup.getPartitions()), Long.toString(result));
         return result;
     }
 
@@ -220,9 +253,13 @@ public class FileRegistry {
      * @throws IOException
      */
     public long getModificationAgeSec(TopicPartition topicPartition) throws IOException {
+        return getModificationAgeSec(new TopicPartitionGroup(topicPartition));
+    }
+
+    public long getModificationAgeSec(TopicPartitionGroup topicPartitionGroup) throws IOException {
         long now = System.currentTimeMillis() / 1000L;
         long result = Long.MAX_VALUE;
-        Collection<LogFilePath> paths = getPaths(topicPartition);
+        Collection<LogFilePath> paths = getPaths(topicPartitionGroup);
         for (LogFilePath path : paths) {
             Long creationTime = mCreationTimes.get(path);
             if (creationTime == null) {
@@ -237,8 +274,8 @@ public class FileRegistry {
         if (result == Long.MAX_VALUE) {
             result = -1;
         }
-        StatsUtil.setLabel("secor.modification_age_sec." + topicPartition.getTopic() + "." +
-            topicPartition.getPartition(), Long.toString(result));
+        StatsUtil.setLabel("secor.modification_age_sec." + topicPartitionGroup.getTopic() + "." +
+            Arrays.toString(topicPartitionGroup.getPartitions()), Long.toString(result));
         return result;
     }
 }

--- a/src/main/java/com/pinterest/secor/common/LogFilePath.java
+++ b/src/main/java/com/pinterest/secor/common/LogFilePath.java
@@ -17,8 +17,12 @@
 package com.pinterest.secor.common;
 
 import com.pinterest.secor.message.ParsedMessage;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -46,38 +50,51 @@ public class LogFilePath {
     private final String mTopic;
     private final String[] mPartitions;
     private final int mGeneration;
-    private final int mKafkaPartition;
-    private final long mOffset;
+    private final int[] mKafkaPartitions;
+    private final long[] mOffsets;
     private final String mExtension;
+    private MessageDigest messageDigest;
+
+
+    public LogFilePath(String prefix, String topic, String[] partitions, int generation,
+                       int[] kafkaPartitions, long[] offsets, String extension) {
+        assert kafkaPartitions != null & kafkaPartitions.length >= 1
+            : "Wrong kafkaParttions: " + Arrays.toString(kafkaPartitions);
+        assert offsets != null & offsets.length >= 1 : "Wrong offsets: " + Arrays.toString(offsets);
+        assert kafkaPartitions.length == offsets.length
+            : "Size mismatch partitions: " + Arrays.toString(kafkaPartitions) +
+            " offsets: " + Arrays.toString(offsets);
+        for (int i = 1; i < kafkaPartitions.length; i++) {
+            assert kafkaPartitions[i] == kafkaPartitions[i - 1] + 1
+                : "Non consecutive partitions " + kafkaPartitions[i] +
+                " and " + kafkaPartitions[i-1];
+        }
+        mPrefix = prefix;
+        mTopic = topic;
+        mPartitions = Arrays.copyOf(partitions, partitions.length);
+        mGeneration = generation;
+        mKafkaPartitions = Arrays.copyOf(kafkaPartitions, kafkaPartitions.length);
+        mOffsets = Arrays.copyOf(offsets, offsets.length);
+        mExtension = extension;
+
+        try {
+            messageDigest = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Unable to find mdt digest.", e);
+        }
+    }
 
     public LogFilePath(String prefix, int generation, long lastCommittedOffset,
                        ParsedMessage message, String extension) {
-        mPrefix = prefix;
-        mTopic = message.getTopic();
-        mPartitions = message.getPartitions();
-        mGeneration = generation;
-        mKafkaPartition = message.getKafkaPartition();
-        mOffset = lastCommittedOffset;
-        mExtension = extension;
+        this(prefix, message.getTopic(), message.getPartitions(), generation,
+            new int[]{message.getKafkaPartition()}, new long[]{lastCommittedOffset},
+            extension);
     }
 
     public LogFilePath(String prefix, String topic, String[] partitions, int generation,
                        int kafkaPartition, long offset, String extension) {
-        mPrefix = prefix;
-        mTopic = topic;
-        mPartitions = partitions;
-        mGeneration = generation;
-        mKafkaPartition = kafkaPartition;
-        mOffset = offset;
-        mExtension = extension;
-    }
-
-    private static String[] subArray(String[] array, int startIndex, int endIndex) {
-        String[] result = new String[endIndex - startIndex + 1];
-        for (int i = startIndex; i <= endIndex; ++i) {
-            result[i - startIndex] = array[i];
-        }
-        return result;
+        this(prefix, topic, partitions, generation, new int[]{kafkaPartition},
+            new long[]{offset}, extension);
     }
 
     public LogFilePath(String prefix, String path) {
@@ -110,12 +127,21 @@ public class LogFilePath {
         String[] basenameElements = basename.split("_");
         assert basenameElements.length == 3: Integer.toString(basenameElements.length) + " == 3";
         mGeneration = Integer.parseInt(basenameElements[0]);
-        mKafkaPartition = Integer.parseInt(basenameElements[1]);
-        mOffset = Long.parseLong(basenameElements[2]);
+        mKafkaPartitions = new int[]{Integer.parseInt(basenameElements[1])};
+        mOffsets = new long[]{Long.parseLong(basenameElements[2])};
+    }
+
+    private static String[] subArray(String[] array, int startIndex, int endIndex) {
+        String[] result = new String[endIndex - startIndex + 1];
+        for (int i = startIndex; i <= endIndex; ++i) {
+            result[i - startIndex] = array[i];
+        }
+        return result;
     }
 
     public LogFilePath withPrefix(String prefix) {
-        return new LogFilePath(prefix, mTopic, mPartitions, mGeneration, mKafkaPartition, mOffset, mExtension);
+        return new LogFilePath(prefix, mTopic, mPartitions, mGeneration, mKafkaPartitions, mOffsets,
+            mExtension);
     }
 
     public String getLogFileParentDir() {
@@ -137,8 +163,26 @@ public class LogFilePath {
     private String getLogFileBasename() {
         ArrayList<String> basenameElements = new ArrayList<String>();
         basenameElements.add(Integer.toString(mGeneration));
-        basenameElements.add(Integer.toString(mKafkaPartition));
-        basenameElements.add(String.format("%020d", mOffset));
+        if (mKafkaPartitions.length > 1) {
+            String kafkaPartitions = mKafkaPartitions[0] + "-" +
+                mKafkaPartitions[mKafkaPartitions.length - 1];
+            basenameElements.add(kafkaPartitions);
+
+            StringBuilder sb = new StringBuilder();
+            for (long offset : mOffsets) {
+                sb.append(offset);
+            }
+            try {
+                byte[] md5Bytes = messageDigest.digest(sb.toString().getBytes("UTF-8"));
+                byte[] encodedBytes = Base64.encodeBase64URLSafe(md5Bytes);
+                basenameElements.add(new String(encodedBytes));
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            basenameElements.add(Integer.toString(mKafkaPartitions[0]));
+            basenameElements.add(String.format("%020d", mOffsets[0]));
+        }
         return StringUtils.join(basenameElements, "_");
     }
 
@@ -174,12 +218,22 @@ public class LogFilePath {
         return mGeneration;
     }
 
+    @Deprecated
     public int getKafkaPartition() {
-        return mKafkaPartition;
+        return mKafkaPartitions[0];
     }
 
+    public int[] getKafkaPartitions() {
+        return mKafkaPartitions;
+    }
+
+    @Deprecated
     public long getOffset() {
-        return mOffset;
+        return mOffsets[0];
+    }
+
+    public long[] getOffsets() {
+        return mOffsets;
     }
 
     public String getExtension() {
@@ -194,8 +248,8 @@ public class LogFilePath {
         LogFilePath that = (LogFilePath) o;
 
         if (mGeneration != that.mGeneration) return false;
-        if (mKafkaPartition != that.mKafkaPartition) return false;
-        if (mOffset != that.mOffset) return false;
+        if (!Arrays.equals(mKafkaPartitions, that.mKafkaPartitions)) return false;
+        if (!Arrays.equals(mOffsets, that.mOffsets)) return false;
         if (!Arrays.equals(mPartitions, that.mPartitions)) return false;
         if (mPrefix != null ? !mPrefix.equals(that.mPrefix) : that.mPrefix != null) return false;
         if (mTopic != null ? !mTopic.equals(that.mTopic) : that.mTopic != null) return false;
@@ -209,8 +263,8 @@ public class LogFilePath {
         result = 31 * result + (mTopic != null ? mTopic.hashCode() : 0);
         result = 31 * result + (mPartitions != null ? Arrays.hashCode(mPartitions) : 0);
         result = 31 * result + mGeneration;
-        result = 31 * result + mKafkaPartition;
-        result = 31 * result + (int) (mOffset ^ (mOffset >>> 32));
+        result = 31 * result + Arrays.hashCode(mKafkaPartitions);
+        result = 31 * result + Arrays.hashCode(mOffsets);
         return result;
     }
 

--- a/src/main/java/com/pinterest/secor/common/TopicPartitionGroup.java
+++ b/src/main/java/com/pinterest/secor/common/TopicPartitionGroup.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.common;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Topic partition group describes a kafka message topic-partitions pair.
+ *
+ * @author Henry Cai (hcai@pinterest.com)
+ */
+public class TopicPartitionGroup {
+    private String mTopic;
+    private int[] mPartitions;
+
+    public TopicPartitionGroup(String topic, int[] partitions) {
+        mTopic = topic;
+        mPartitions = Arrays.copyOf(partitions, partitions.length);
+    }
+
+    public TopicPartitionGroup(TopicPartition tp) {
+        this(tp.getTopic(), new int[]{tp.getPartition()});
+    }
+
+    public String getTopic() {
+        return mTopic;
+    }
+
+    public int[] getPartitions() {
+        return mPartitions;
+    }
+
+    public List<TopicPartition> getTopicPartitions() {
+        List<TopicPartition> tps = new ArrayList<TopicPartition>();
+        for (int p : mPartitions) {
+            tps.add(new TopicPartition(mTopic, p));
+        }
+        return tps;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        TopicPartitionGroup that = (TopicPartitionGroup) o;
+
+        if (!Arrays.equals(mPartitions, that.mPartitions)) return false;
+        if (mTopic != null ? !mTopic.equals(that.mTopic) : that.mTopic != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = mTopic != null ? mTopic.hashCode() : 0;
+        result = 31 * result + Arrays.hashCode(mPartitions);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "TopicPartitionGroup{" +
+                "mTopic='" + mTopic + '\'' +
+                ", mPartitions=" + Arrays.toString(mPartitions) +
+                '}';
+    }
+}

--- a/src/main/java/com/pinterest/secor/io/impl/SequenceFileReaderWriterFactory.java
+++ b/src/main/java/com/pinterest/secor/io/impl/SequenceFileReaderWriterFactory.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.compress.CompressionCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.pinterest.secor.common.LogFilePath;
 import com.pinterest.secor.io.KeyValue;
@@ -40,6 +42,9 @@ import com.pinterest.secor.util.FileUtil;
  * @author Praveen Murugesan (praveen@uber.com)
  */
 public class SequenceFileReaderWriterFactory implements FileReaderWriterFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SequenceFileReaderWriterFactory.class);
+
     @Override
     public FileReader BuildFileReader(LogFilePath logFilePath, CompressionCodec codec) throws Exception {
         return new SequenceFileReader(logFilePath);
@@ -83,10 +88,11 @@ public class SequenceFileReaderWriterFactory implements FileReaderWriterFactory 
         private final SequenceFile.Writer mWriter;
         private final LongWritable mKey;
         private final BytesWritable mValue;
+        private final Path fsPath;
 
         public SequenceFileWriter(LogFilePath path, CompressionCodec codec) throws IOException {
             Configuration config = new Configuration();
-            Path fsPath = new Path(path.getLogFilePath());
+            fsPath = new Path(path.getLogFilePath());
             FileSystem fs = FileUtil.getFileSystem(path.getLogFilePath());
             if (codec != null) {
                 this.mWriter = SequenceFile.createWriter(fs, config, fsPath,
@@ -98,6 +104,7 @@ public class SequenceFileReaderWriterFactory implements FileReaderWriterFactory 
             }
             this.mKey = new LongWritable();
             this.mValue = new BytesWritable();
+            LOG.info("Created sequence file writer: {}", fsPath);
         }
 
         @Override
@@ -115,6 +122,7 @@ public class SequenceFileReaderWriterFactory implements FileReaderWriterFactory 
         @Override
         public void close() throws IOException {
             this.mWriter.close();
+            LOG.info("Closing sequence file writer: {}", fsPath);
         }
     }
 }


### PR DESCRIPTION
    File Coalescing: Enhance FileRegistry and LogFilePath to have the capability of specifying multiple partitions
    
    We want to achieve a file coalescing feature currently in Spark streaming, for slow volume topic or if you upload by minute, we want to reduce the numbe
    
    Enhance the FileRegistry and LogFilePath to allow a file path represent multiple kafka partitions encoded as:
      topic/dt=XX/hr=XX/generationNumber_startKafkaPartition-endKafkaPartition_MD5-encoded-partition-offsets

