### PR TITLE
Resolve hadoop and aws conflict from #232

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,8 @@
         <maven.compiler.target>1.6</maven.compiler.target>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.aws>1.10.6</version.aws>
+        <version.hadoop>3.0.0-alpha1</version.hadoop>
     </properties>
 
     <distributionManagement>
@@ -94,12 +96,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.68</version>
+            <version>${version.aws}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
-            <version>1.10.68</version>
+            <version>${version.aws}</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jets3t</groupId>
@@ -160,12 +162,12 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.7.0</version>
+            <version>${version.hadoop}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-aws</artifactId>
-            <version>2.7.0</version>
+            <version>${version.hadoop}</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.java.dev.jets3t</groupId>
@@ -192,7 +194,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-openstack</artifactId>
-            <version>2.7.0</version>
+            <version>${version.hadoop}</version>
         </dependency>
 
         <!-- Parquet file format dependencies -->


### PR DESCRIPTION
Not sure on the policies regarding the use of alpha/snapshot dependencies in snapshots here, but the Hadoop s3a file system requires that that the AWS artifact versions match exactly as stated [here](https://wiki.apache.org/hadoop/AmazonS3):

> S3A requires the exact version of the amazon-aws-sdk against which Hadoop was built 
> (and is bundled with). If you try to upgrade the library by dropping in a later version, things 
> will break.

Thus, this pull request moves up to Hadoop 3.0.0-alpha and back to AWS 1.10.6.