### PR TITLE
added timeout to qubole calls

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -302,3 +302,9 @@ secor.s3.alter.path.date=
 
 # An alternative S3 path for secor to upload files to
 secor.s3.alternative.path=
+
+# If enabled, add calls will be made to qubole, otherwise, skip qubole call for finalization
+secor.enable.qubole=true
+
+# Timeout value for qubole calls
+secor.qubole.timeout.ms=300000

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -376,6 +376,8 @@ public class SecorConfig {
         return mProperties.getString(key, null);
     }
 
+    public boolean getSkipQuboleAddPartition() { return getBoolean("secor.skip.qubole.add.partition", false); }
+
     public String getCompressionCodec() {
         return getString("secor.compression.codec");
     }

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -506,10 +506,6 @@ public class SecorConfig {
         return mProperties.getLong(name);
     }
 
-    public long getLong(String name, long defaultValue) {
-        return mProperties.getLong(name, defaultValue);
-    }
-
     public String[] getStringArray(String name) {
         return mProperties.getStringArray(name);
     }

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -383,11 +383,11 @@ public class SecorConfig {
     }
 
     public boolean getQuboleEnabled() {
-        return getBoolean("secor.enable.qubole", true);
+        return getBoolean("secor.enable.qubole");
     }
 
     public long getQuboleTimeoutMs() {
-        return getLong("secor.qubole.timeout.ms", 300000);
+        return getLong("secor.qubole.timeout.ms");
     }
 
     public String getCompressionCodec() {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -376,7 +376,13 @@ public class SecorConfig {
         return mProperties.getString(key, null);
     }
 
-    public boolean getSkipQuboleAddPartition() { return getBoolean("secor.skip.qubole.add.partition", false); }
+    public boolean getQuboleEnabled() {
+        return getBoolean("secor.enable.qubole", true);
+    }
+
+    public long getQuboleTimeoutMs() {
+        return getLong("secor.qubole.timeout.ms", 300000);
+    }
 
     public String getCompressionCodec() {
         return getString("secor.compression.codec");
@@ -480,6 +486,10 @@ public class SecorConfig {
 
     public long getLong(String name) {
         return mProperties.getLong(name);
+    }
+
+    public long getLong(String name, long defaultValue) {
+        return mProperties.getLong(name, defaultValue);
     }
 
     public String[] getStringArray(String name) {

--- a/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
+++ b/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
@@ -168,7 +168,7 @@ public class PartitionFinalizer {
                             LOG.warn("HivePrefix is not defined.  Skip hive registration");
                         }
                     }
-                    if (hiveTableName != null && !mConfig.getSkipQuboleAddPartition()) {
+                    if (hiveTableName != null && mConfig.getQuboleEnabled()) {
                         mQuboleClient.addPartition(hiveTableName, sb.toString());
                     }
                 } catch (Exception e) {

--- a/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
+++ b/src/main/java/com/pinterest/secor/parser/PartitionFinalizer.java
@@ -168,7 +168,7 @@ public class PartitionFinalizer {
                             LOG.warn("HivePrefix is not defined.  Skip hive registration");
                         }
                     }
-                    if (hiveTableName != null) {
+                    if (hiveTableName != null && !mConfig.getSkipQuboleAddPartition()) {
                         mQuboleClient.addPartition(hiveTableName, sb.toString());
                     }
                 } catch (Exception e) {

--- a/src/main/java/com/pinterest/secor/parser/QuboleClient.java
+++ b/src/main/java/com/pinterest/secor/parser/QuboleClient.java
@@ -31,6 +31,8 @@ import java.util.Map;
  * @author Pawel Garbacki (pawel@pinterest.com)
  */
 public class QuboleClient {
+    private static final long MAX_QUBOLE_WAIT_TIME_MS = 300000; // 5 minutes
+
     private String mApiToken;
 
     public QuboleClient(SecorConfig config) {
@@ -94,24 +96,28 @@ public class QuboleClient {
         return (Integer) response.get("id");
     }
 
-    private void waitForCompletion(int commandId) throws IOException, InterruptedException {
+    private int waitForCompletion(int commandId, long timeout) throws IOException, InterruptedException {
         URL url = new URL("https://api.qubole.com/api/v1.2/commands/" + commandId);
-        while (true) {
+        long endTime = System.currentTimeMillis() + timeout;
+
+        while (System.currentTimeMillis() < endTime) {
             Map response = makeRequest(url, null);
             if (response.get("status").equals("done")) {
-                return;
+                return 0;
             }
             System.out.println("waiting 3 seconds for results of query " + commandId +
                                ". Current status " + response.get("status"));
             Thread.sleep(3000);
         }
+
+        return 1; // qubole call failed to return within timeout
     }
 
-    public void addPartition(String table, String partition) throws IOException,
+    public int addPartition(String table, String partition) throws IOException,
             InterruptedException {
         String queryStr = "ALTER TABLE " + table + " ADD IF NOT EXISTS PARTITION (" + partition +
             ")";
         int commandId = query(queryStr);
-        waitForCompletion(commandId);
+        return waitForCompletion(commandId, MAX_QUBOLE_WAIT_TIME_MS);
     }
 }

--- a/src/main/java/com/pinterest/secor/parser/QuboleClient.java
+++ b/src/main/java/com/pinterest/secor/parser/QuboleClient.java
@@ -31,12 +31,13 @@ import java.util.Map;
  * @author Pawel Garbacki (pawel@pinterest.com)
  */
 public class QuboleClient {
-    private static final long MAX_QUBOLE_WAIT_TIME_MS = 300000; // 5 minutes
+    private final long MAX_QUBOLE_WAIT_TIME_MS;
 
     private String mApiToken;
 
     public QuboleClient(SecorConfig config) {
         mApiToken = config.getQuboleApiToken();
+        MAX_QUBOLE_WAIT_TIME_MS = config.getQuboleTimeoutMs();
     }
 
     private Map makeRequest(URL url, String body) throws IOException {

--- a/src/main/java/com/pinterest/secor/parser/QuboleClient.java
+++ b/src/main/java/com/pinterest/secor/parser/QuboleClient.java
@@ -96,28 +96,28 @@ public class QuboleClient {
         return (Integer) response.get("id");
     }
 
-    private int waitForCompletion(int commandId, long timeout) throws IOException, InterruptedException {
+    private void waitForCompletion(int commandId, long timeout) throws IOException, InterruptedException {
         URL url = new URL("https://api.qubole.com/api/v1.2/commands/" + commandId);
         long endTime = System.currentTimeMillis() + timeout;
 
         while (System.currentTimeMillis() < endTime) {
             Map response = makeRequest(url, null);
             if (response.get("status").equals("done")) {
-                return 0;
+                return;
             }
             System.out.println("waiting 3 seconds for results of query " + commandId +
                                ". Current status " + response.get("status"));
             Thread.sleep(3000);
         }
 
-        return 1; // qubole call failed to return within timeout
+        throw new IOException("Qubole commandId" + commandId + " failed to return within timeout.");
     }
 
-    public int addPartition(String table, String partition) throws IOException,
+    public void addPartition(String table, String partition) throws IOException,
             InterruptedException {
         String queryStr = "ALTER TABLE " + table + " ADD IF NOT EXISTS PARTITION (" + partition +
-            ")";
+                ")";
         int commandId = query(queryStr);
-        return waitForCompletion(commandId, MAX_QUBOLE_WAIT_TIME_MS);
+        waitForCompletion(commandId, MAX_QUBOLE_WAIT_TIME_MS);
     }
 }


### PR DESCRIPTION
Since calls to qubole can hang, we want to add a timeout option to the add partition call so that it doesnt block the partition finalizer. Also change method to return a code depending on success of call so that upstream calls can retry if needed. 