### PR TITLE
Protobuf 3 and google.protobuf.Timestamp type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,12 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>2.6.1</version>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -401,7 +406,7 @@
 			<plugin>
 				<groupId>com.github.os72</groupId>
 				<artifactId>protoc-jar-maven-plugin</artifactId>
-				<version>3.0.0-b3</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<id>protobuf-test-sources</id>
@@ -410,13 +415,14 @@
 							<goal>run</goal>
 						</goals>
 						<configuration>
-							<protocVersion>2.6.1</protocVersion>
+							<protocVersion>3.1.0</protocVersion>
 							<includeDirectories>
 								<include>src/test/protobuf</include>
 							</includeDirectories>
 							<inputDirectories>
 								<include>src/test/protobuf</include>
 							</inputDirectories>
+                            <includeStdTypes>true</includeStdTypes>
 							<outputTargets>
 								<outputTarget>
 									<type>java</type>

--- a/src/main/java/com/pinterest/secor/parser/ProtobufMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/ProtobufMessageParser.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.regex.Pattern;
 
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.util.Timestamps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,7 +78,7 @@ public class ProtobufMessageParser extends TimestampedMessageParser {
             Object timestampObject = decodedMessage
                     .getField(decodedMessage.getDescriptorForType().findFieldByName(timestampFieldPath[i]));
             if (timestampObject instanceof com.google.protobuf.Timestamp){
-                return toMillis((com.google.protobuf.Timestamp)timestampObject);
+                return Timestamps.toMillis((com.google.protobuf.Timestamp) timestampObject);
             }else {
                 return toMillis((Long) timestampObject);
             }

--- a/src/main/java/com/pinterest/secor/parser/ProtobufMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/ProtobufMessageParser.java
@@ -19,6 +19,7 @@ package com.pinterest.secor.parser;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
+import com.google.protobuf.Descriptors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,8 +74,13 @@ public class ProtobufMessageParser extends TimestampedMessageParser {
                 decodedMessage = (com.google.protobuf.Message) decodedMessage
                         .getField(decodedMessage.getDescriptorForType().findFieldByName(timestampFieldPath[i]));
             }
-            return toMillis((Long) decodedMessage
-                    .getField(decodedMessage.getDescriptorForType().findFieldByName(timestampFieldPath[i])));
+            Object timestampObject = decodedMessage
+                    .getField(decodedMessage.getDescriptorForType().findFieldByName(timestampFieldPath[i]));
+            if (timestampObject instanceof com.google.protobuf.Timestamp){
+                return toMillis((com.google.protobuf.Timestamp)timestampObject);
+            }else {
+                return toMillis((Long) timestampObject);
+            }
         } else {
             // Assume that the timestamp field is the first field, is required,
             // and is a uint64.

--- a/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
@@ -97,10 +97,6 @@ public abstract class TimestampedMessageParser extends MessageParser implements 
         return timestampMillis;
     }
 
-    protected static long toMillis(final Timestamp timestamp) {
-       return Timestamps.toMillis(timestamp);
-    }
-
     public abstract long extractTimestampMillis(final Message message) throws Exception;
 
     protected String[] generatePartitions(long timestampMillis, boolean usingHourly, boolean usingMinutely)

--- a/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/TimestampedMessageParser.java
@@ -16,6 +16,8 @@
  */
 package com.pinterest.secor.parser;
 
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.message.Message;
 import org.slf4j.Logger;
@@ -93,6 +95,10 @@ public abstract class TimestampedMessageParser extends MessageParser implements 
             timestampMillis = timestamp * 1000L;
         }
         return timestampMillis;
+    }
+
+    protected static long toMillis(final Timestamp timestamp) {
+       return Timestamps.toMillis(timestamp);
     }
 
     public abstract long extractTimestampMillis(final Message message) throws Exception;

--- a/src/test/java/com/pinterest/secor/parser/ProtobufTimestampParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/ProtobufTimestampParserTest.java
@@ -1,0 +1,93 @@
+package com.pinterest.secor.parser;
+
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import com.pinterest.secor.protobuf.Messages;
+import com.pinterest.secor.protobuf.TimestampedMessages;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by pgautam on 10/9/16.
+ */
+@RunWith(PowerMockRunner.class)
+public class ProtobufTimestampParserTest extends TestCase {
+    private SecorConfig mConfig;
+
+    private Message buildMessage(long timestamp) throws Exception {
+        byte data[] = new byte[16];
+        CodedOutputStream output = CodedOutputStream.newInstance(data);
+        output.writeUInt64(1, timestamp);
+        return new Message("test", 0, 0, null, data);
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        mConfig = Mockito.mock(SecorConfig.class);
+    }
+
+    @Test
+    public void testExtractTimestampMillis() throws Exception {
+        ProtobufMessageParser parser = new ProtobufMessageParser(mConfig);
+
+        assertEquals(1405970352000l, parser.extractTimestampMillis(buildMessage(1405970352l)));
+        assertEquals(1405970352123l, parser.extractTimestampMillis(buildMessage(1405970352123l)));
+    }
+
+    @Test
+    public void testExtractPathTimestampMillis() throws Exception {
+        Map<String, String> classPerTopic = new HashMap<String, String>();
+        System.out.println(TimestampedMessages.UnitTestTimestamp1.class.getName());
+        classPerTopic.put("test", TimestampedMessages.UnitTestTimestamp1.class.getName());
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getProtobufMessageClassPerTopic()).thenReturn(classPerTopic);
+
+        ProtobufMessageParser parser = new ProtobufMessageParser(mConfig);
+
+
+        Timestamp timestamp = Timestamp.newBuilder().setSeconds(1405970352l)
+                .setNanos(0).build();
+
+        TimestampedMessages.UnitTestTimestamp1 message = TimestampedMessages.UnitTestTimestamp1.newBuilder().setTimestamp(timestamp).build();
+        assertEquals(1405970352000l,
+                parser.extractTimestampMillis(new Message("test", 0, 0, null, message.toByteArray())));
+
+        Timestamp timestampWithNano = Timestamp.newBuilder().setSeconds(1405970352l)
+                .setNanos(123000000).build();
+        message = TimestampedMessages.UnitTestTimestamp1.newBuilder().setTimestamp(timestampWithNano).build();
+        assertEquals(1405970352123l,
+                parser.extractTimestampMillis(new Message("test", 0, 0, null, message.toByteArray())));
+    }
+
+    @Test
+    public void testExtractNestedTimestampMillis() throws Exception {
+        Map<String, String> classPerTopic = new HashMap<String, String>();
+        classPerTopic.put("*", TimestampedMessages.UnitTestTimestamp2.class.getName());
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("internal.timestamp");
+        Mockito.when(mConfig.getProtobufMessageClassPerTopic()).thenReturn(classPerTopic);
+
+        ProtobufMessageParser parser = new ProtobufMessageParser(mConfig);
+
+        Timestamp timestamp = Timestamps.fromMillis(1405970352000L);
+
+        TimestampedMessages.UnitTestTimestamp2 message = TimestampedMessages.UnitTestTimestamp2.newBuilder()
+                .setInternal(TimestampedMessages.UnitTestTimestamp2.Internal.newBuilder().setTimestamp(timestamp).build()).build();
+        assertEquals(1405970352000l,
+                parser.extractTimestampMillis(new Message("test", 0, 0, null, message.toByteArray())));
+
+        timestamp = Timestamps.fromMillis(1405970352123l);
+        message = TimestampedMessages.UnitTestTimestamp2.newBuilder()
+                .setInternal(TimestampedMessages.UnitTestTimestamp2.Internal.newBuilder().setTimestamp(timestamp).build()).build();
+        assertEquals(1405970352123l,
+                parser.extractTimestampMillis(new Message("test", 0, 0, null, message.toByteArray())));
+    }
+}

--- a/src/test/protobuf/unittest.proto
+++ b/src/test/protobuf/unittest.proto
@@ -1,5 +1,6 @@
-package com.pinterest.secor.protobuf;
+syntax = "proto2";
 
+package com.pinterest.secor.protobuf;
 option java_package = "com.pinterest.secor.protobuf";
 option java_outer_classname = "Messages";
 

--- a/src/test/protobuf/unittesttimestamp.proto
+++ b/src/test/protobuf/unittesttimestamp.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+package com.pinterest.secor.protobuf;
+
+option java_package = "com.pinterest.secor.protobuf";
+import "google/protobuf/timestamp.proto";
+option java_outer_classname = "TimestampedMessages";
+
+
+message UnitTestTimestamp1 {
+    google.protobuf.Timestamp timestamp = 5;
+}
+
+message UnitTestTimestamp2 {
+	message Internal {
+		google.protobuf.Timestamp timestamp = 1;
+	}
+
+	Internal internal = 1;
+}


### PR DESCRIPTION
Upgrading protobuf dependencies to 3.1.0 which is the latest stable. It is backwards compatible with the existing implementation that uses uint64 for timestamps. The type is checked at parsing time, and the relevant method is called to extract millis, so the rest of the system should continue to work as expected. 

If the tests look good, I can merge them into the same protobuf file to minimize confusion later. 