### PR TITLE
expose an extractTimestampMillis on just bytes for ProtobufMessageParser.

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/ProtobufMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/ProtobufMessageParser.java
@@ -67,9 +67,13 @@ public class ProtobufMessageParser extends TimestampedMessageParser {
 
     @Override
     public long extractTimestampMillis(final Message message) throws IOException {
+        return extractTimestampMillis(message.getTopic(), message.getPayload());
+    }
+
+    public long extractTimestampMillis(String topic, final byte[] bytes) throws IOException {
         if (timestampFieldPath != null) {
-            com.google.protobuf.Message decodedMessage = protobufUtil.decodeMessage(message.getTopic(),
-                    message.getPayload());
+            com.google.protobuf.Message decodedMessage = protobufUtil.decodeMessage(topic,
+                    bytes);
             int i = 0;
             for (; i < timestampFieldPath.length - 1; ++i) {
                 decodedMessage = (com.google.protobuf.Message) decodedMessage
@@ -86,7 +90,7 @@ public class ProtobufMessageParser extends TimestampedMessageParser {
             // Assume that the timestamp field is the first field, is required,
             // and is a uint64.
 
-            CodedInputStream input = CodedInputStream.newInstance(message.getPayload());
+            CodedInputStream input = CodedInputStream.newInstance(bytes);
             // Don't really care about the tag, but need to read it to get, to
             // the payload.
             input.readTag();


### PR DESCRIPTION
I use this class for verifying/indexing protobuf files by time after they've been uploaded in S3 (as Seqfiles, so the process is the same as processing JSON files). I'd send the rest of the project as a PR but it's not quite ready yet. This minor fix is to allow extracting timestamp on the underlying byte array and topic combination without changing the existing method signature that's used upstream and exposed by the service. I don't think adding this in TimestampedMessageParser is a good idea but I can see this being useful there too.