### PR TITLE
Extend ProgressMonitorMain to run in a loop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ Progress monitor exports offset consumption lags per topic partition to [OpenTSD
 java -ea -Dlog4j.configuration=log4j.prod.properties -Dconfig=secor.prod.backup.properties -cp "secor-0.1-SNAPSHOT.jar:lib/*" com.pinterest.secor.main.ProgressMonitorMain
 ```
 
+Set `monitoring.interval.seconds` to a value larger than 0 to run in a loop, exporting stats every `monitoring.interval.seconds` seconds.
+
+
 ## Detailed design
 
 Design details are available in [DESIGN.md](DESIGN.md).

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -247,8 +247,12 @@ tsdb.hostport=
 # Regex of topics that are not exported to TSDB.
 monitoring.blacklist.topics=
 
-# Prefix of exported statss.
+# Prefix of exported stats.
 monitoring.prefix=secor
+
+# Monitoring interval.
+# Set to 0 to disable - the progress monitor will run once and exit.
+monitoring.interval.seconds=0
 
 # Secor can export stats to statsd such as consumption lag (in seconds and offsets) per topic partition.
 # Leave empty to disable this functionality.

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -349,6 +349,10 @@ public class SecorConfig {
         return getString("monitoring.prefix");
     }
 
+    public long getMonitoringIntervalSeconds() {
+        return getLong("monitoring.interval.seconds", 0);
+    }
+
     public String getMessageTimestampName() {
         return getString("message.timestamp.name");
     }
@@ -508,6 +512,10 @@ public class SecorConfig {
 
     public long getLong(String name) {
         return mProperties.getLong(name);
+    }
+
+    public long getLong(String name, long defaultValue) {
+	return mProperties.getLong(name, defaultValue);
     }
 
     public String[] getStringArray(String name) {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -350,7 +350,7 @@ public class SecorConfig {
     }
 
     public long getMonitoringIntervalSeconds() {
-        return getLong("monitoring.interval.seconds", 0);
+        return getLong("monitoring.interval.seconds");
     }
 
     public String getMessageTimestampName() {
@@ -512,10 +512,6 @@ public class SecorConfig {
 
     public long getLong(String name) {
         return mProperties.getLong(name);
-    }
-
-    public long getLong(String name, long defaultValue) {
-	return mProperties.getLong(name, defaultValue);
     }
 
     public String[] getStringArray(String name) {


### PR DESCRIPTION
The interval between stats exports is set by
`monitoring.interval.seconds`. Setting to zero (the default) causes the
monitor to export once and then exit (existing behavior).