### PR TITLE
Make consumer group prefix on statsd metrics optional.

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -254,6 +254,22 @@ monitoring.prefix=secor
 # Leave empty to disable this functionality.
 statsd.hostport=
 
+# If true, the consumer group will be the initial prefix of all
+# exported metrics, before `monitoring.prefix` (if set).
+#
+# Setting to false and use monitoring.prefix can lead to nice paths.
+# For example,
+#   secor.kafka.group = secor_hr_partition
+#   monitoring.prefix = secor.hr
+#   statsd.prefixWithConsumerGroup = false
+#   => secor.hr.lag.offsets.<topic>.<partition>
+#
+#   secor.kafka.group = secor_hr_partition
+#   monitoring.prefix = secor
+#   statsd.prefixWithConsumerGroup = true
+#   => secor_hr_partition.secor.lag.offsets.<topic>.<partition>
+statsd.prefixWithConsumerGroup=true
+
 # Name of field that contains timestamp for JSON, MessagePack, or Thrift message parser. (1405970352123)
 message.timestamp.name=timestamp
 

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -341,6 +341,10 @@ public class SecorConfig {
         return getString("statsd.hostport");
     }
 
+    public boolean getStatsDPrefixWithConsumerGroup(){
+    	return getBoolean("statsd.prefixWithConsumerGroup", true);
+    }
+
     public String getMonitoringBlacklistTopics() {
         return getString("monitoring.blacklist.topics");
     }

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -342,7 +342,7 @@ public class SecorConfig {
     }
 
     public boolean getStatsDPrefixWithConsumerGroup(){
-    	return getBoolean("statsd.prefixWithConsumerGroup", true);
+    	return getBoolean("statsd.prefixWithConsumerGroup");
     }
 
     public String getMonitoringBlacklistTopics() {

--- a/src/main/java/com/pinterest/secor/tools/ProgressMonitor.java
+++ b/src/main/java/com/pinterest/secor/tools/ProgressMonitor.java
@@ -63,6 +63,7 @@ public class ProgressMonitor {
     private KafkaClient mKafkaClient;
     private MessageParser mMessageParser;
     private String mPrefix;
+    private NonBlockingStatsDClient mStatsDClient;
 
     public ProgressMonitor(SecorConfig config)
             throws Exception
@@ -76,6 +77,11 @@ public class ProgressMonitor {
         mPrefix = mConfig.getMonitoringPrefix();
         if (Strings.isNullOrEmpty(mPrefix)) {
             mPrefix = "secor";
+        }
+
+        if (mConfig.getStatsDHostPort() != null && !mConfig.getStatsDHostPort().isEmpty()) {
+            HostAndPort hostPort = HostAndPort.fromString(mConfig.getStatsDHostPort());
+            mStatsDClient = new NonBlockingStatsDClient(null, hostPort.getHostText(), hostPort.getPort());
         }
     }
 
@@ -139,7 +145,7 @@ public class ProgressMonitor {
         }
 
         // if there is a valid statsD port configured export to statsD
-        if (mConfig.getStatsDHostPort() != null && !mConfig.getStatsDHostPort().isEmpty()) {
+        if (mStatsDClient != null) {
             exportToStatsD(stats);
         }
     }
@@ -148,22 +154,24 @@ public class ProgressMonitor {
      * Helper to publish stats to statsD client
      */
     private void exportToStatsD(List<Stat> stats) {
-        HostAndPort hostPort = HostAndPort.fromString(mConfig.getStatsDHostPort());
-
         // group stats by kafka group
-        NonBlockingStatsDClient client = new NonBlockingStatsDClient(mConfig.getKafkaGroup(),
-                hostPort.getHostText(), hostPort.getPort());
-
         for (Stat stat : stats) {
             @SuppressWarnings("unchecked")
             Map<String, String> tags = (Map<String, String>) stat.get(Stat.STAT_KEYS.TAGS.getName());
-            String aspect = new StringBuilder((String)stat.get(Stat.STAT_KEYS.METRIC.getName()))
-                    .append(PERIOD)
-                    .append(tags.get(Stat.STAT_KEYS.TOPIC.getName()))
-                    .append(PERIOD)
-                    .append(tags.get(Stat.STAT_KEYS.PARTITION.getName()))
-                    .toString();
-            client.recordGaugeValue(aspect, Long.parseLong((String)stat.get(Stat.STAT_KEYS.VALUE.getName())));
+            StringBuilder builder = new StringBuilder();
+	    if (mConfig.getStatsDPrefixWithConsumerGroup()) {
+		builder.append(tags.get(Stat.STAT_KEYS.GROUP.getName()))
+		    .append(PERIOD);
+	    }
+	    String aspect = builder
+		.append((String)stat.get(Stat.STAT_KEYS.METRIC.getName()))
+		.append(PERIOD)
+		.append(tags.get(Stat.STAT_KEYS.TOPIC.getName()))
+		.append(PERIOD)
+		.append(tags.get(Stat.STAT_KEYS.PARTITION.getName()))
+		.toString();
+            long value = Long.parseLong((String)stat.get(Stat.STAT_KEYS.VALUE.getName()));
+            mStatsDClient.recordGaugeValue(aspect, value);
         }
     }
 


### PR DESCRIPTION
The default is the current behavior, which is to include the consumer
group as the overall prefix. Disable by setting
`secor.prefixWithConsumerGroup` to false.