### PR TITLE
Allow auto.offset.reset to be specified in configuration.

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -128,6 +128,14 @@ secor.zookeeper.path=/
 # Impacts how frequently the upload logic is triggered if no messages are delivered.
 kafka.consumer.timeout.ms=10000
 
+# Where consumer should read from if no committed offset in zookeeper.
+#   "smallest" -> read from earliest offset
+#   "largest"  -> read from latest offset
+# Always use "smallest" unless you know what you're doing and are willing to risk
+# data loss for new topics or topics whose number of partitions has changed.
+# See the kafka docs for "auto.offset.reset".
+kafka.consumer.auto.offset.reset=smallest
+
 # Choose between range and roundrobin partition assignment strategy for kafka
 # high level consumers. Check PartitionAssignor.scala in kafa 821 module for
 # the differences between the two.

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -92,7 +92,7 @@ public class SecorConfig {
     }
 
     public String getConsumerAutoOffsetReset() {
-        return getString("kafka.consumer.auto.offset.reset", "smallest");
+        return getString("kafka.consumer.auto.offset.reset");
     }
 
     public String getPartitionAssignmentStrategy() {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -91,6 +91,10 @@ public class SecorConfig {
         return getInt("kafka.consumer.timeout.ms");
     }
 
+    public String getConsumerAutoOffsetReset() {
+        return getString("kafka.consumer.auto.offset.reset", "smallest");
+    }
+
     public String getPartitionAssignmentStrategy() {
         return getString("kafka.partition.assignment.strategy");
     }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -116,9 +116,7 @@ public class MessageReader {
                   Integer.toString(mConfig.getZookeeperSessionTimeoutMs()));
         props.put("zookeeper.sync.time.ms", Integer.toString(mConfig.getZookeeperSyncTimeMs()));
         props.put("auto.commit.enable", "false");
-        // This option is required to make sure that messages are not lost for new topics and
-        // topics whose number of partitions has changed.
-        props.put("auto.offset.reset", "smallest");
+        props.put("auto.offset.reset", mConfig.getConsumerAutoOffsetReset());
         props.put("consumer.timeout.ms", Integer.toString(mConfig.getConsumerTimeoutMs()));
         props.put("consumer.id", IdUtil.getConsumerId());
         // Properties required to upgrade from kafka 0.8.x to 0.9.x


### PR DESCRIPTION
In most cases, the value should not be set to anything other than
"smallest". However, "largest" can be useful when transitioning from
to secor from another logsaver in situations where everything up to
largest has already been saved.