### PR TITLE
Fix DelimitedTextFileWriter.getLength

### DIFF
--- a/src/main/java/com/pinterest/secor/io/impl/DelimitedTextFileReaderWriterFactory.java
+++ b/src/main/java/com/pinterest/secor/io/impl/DelimitedTextFileReaderWriterFactory.java
@@ -117,6 +117,7 @@ public class DelimitedTextFileReaderWriterFactory implements FileReaderWriterFac
         @Override
         public long getLength() throws IOException {
             assert this.mCountingStream != null;
+            this.mWriter.flush();
             return this.mCountingStream.getCount();
         }
 


### PR DESCRIPTION
Currently, at least for DelimitedTextFileWriter, the getLength returned value doesn't take into account data that not flushed yet (returns 0).
As a result, in Uploader.checkTopicPartition wrong decision can happen:  "size >= mConfig.getMaxFileSizeBytes()" while data already cashed and much larger than "secor.max.file.size.bytes".

It is worth to check other writers as well.