### PR TITLE
Allow secor.properties to specify AWS S3 path style bucket specification

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -54,6 +54,10 @@ aws.proxy.http.port=
 aws.region=
 aws.endpoint=
 
+# Toggle the AWS S3 client between virtual host style access and path style
+# access. See http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html
+aws.client.pathstyleaccess=false
+
 ###########################
 # START AWS S3 ENCRYPTION #
 ###########################

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -273,6 +273,10 @@ public class SecorConfig {
         return getString("aws.role");
     }
 
+    public boolean getAwsClientPathStyleAccess() {
+        return getBoolean("aws.client.pathstyleaccess", false);
+    }
+
     public boolean getAwsProxyEnabled(){
     	return getBoolean("aws.proxy.isEnabled");
     }

--- a/src/main/java/com/pinterest/secor/uploader/S3UploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/S3UploadManager.java
@@ -28,6 +28,7 @@ import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.transfer.Upload;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.auth.AWSCredentials;
@@ -117,6 +118,12 @@ public class S3UploadManager extends UploadManager {
         }
 
         client = new AmazonS3Client(provider, clientConfiguration);
+
+        if (mConfig.getAwsClientPathStyleAccess()) {
+            S3ClientOptions clientOptions = new S3ClientOptions();
+            clientOptions.setPathStyleAccess(true);
+            client.setS3ClientOptions(clientOptions);
+        }
 
         if (!endpoint.isEmpty()) {
             client.setEndpoint(endpoint);


### PR DESCRIPTION
This allows users to specify virtual host style (current way - stays by default if config not changed) and path style bucket specification for S3 in secor properties. See [S3 doc](http://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html).

I wanted to do some local testing with [Minio](https://www.minio.io/) which needed path style. Otherwise, Secor works perfectly with Minio using the S3 compatible interface :-)