### PR TITLE
if no prefix/topic, don't add empty component to path

### DIFF
--- a/src/main/java/com/pinterest/secor/common/LogFilePath.java
+++ b/src/main/java/com/pinterest/secor/common/LogFilePath.java
@@ -146,10 +146,10 @@ public class LogFilePath {
 
     public String getLogFileParentDir() {
         ArrayList<String> elements = new ArrayList<String>();
-        if(mPrefix.length() > 0) {
+        if (mPrefix != null && mPrefix.length() > 0) {
             elements.add(mPrefix);
         }
-        if(mTopic.length() > 0) {
+        if (mTopic != null && mTopic.length() > 0) {
             elements.add(mTopic);
         }
         return StringUtils.join(elements, "/");

--- a/src/main/java/com/pinterest/secor/common/LogFilePath.java
+++ b/src/main/java/com/pinterest/secor/common/LogFilePath.java
@@ -146,8 +146,12 @@ public class LogFilePath {
 
     public String getLogFileParentDir() {
         ArrayList<String> elements = new ArrayList<String>();
-        elements.add(mPrefix);
-        elements.add(mTopic);
+        if(mPrefix.length() > 0) {
+            elements.add(mPrefix);
+        }
+        if(mTopic.length() > 0) {
+            elements.add(mTopic);
+        }
         return StringUtils.join(elements, "/");
     }
 


### PR DESCRIPTION
I had problems with paths ending up with an extra `/`  when `secor.s3.path` was empty which got encoded as a `%2f` in the path. This fixes that problem and potentially others associated with joining empty components into the path. I may just be doing something wrong elsewhere though?