### PR TITLE
Added configurable date prefixes

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
@@ -58,7 +58,7 @@ public class DateMessageParser extends MessageParser {
         inputFormatter.setTimeZone(timeZone);
         outputFormatter.setTimeZone(timeZone);
 
-        mDtPrefix = (TimestampedMessageParser.usingDatePrefix(config) == null) ? "" : TimestampedMessageParser.usingDatePrefix(config);
+        mDtPrefix = TimestampedMessageParser.usingDatePrefix(config);
     }
 
     @Override

--- a/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
@@ -30,7 +30,7 @@ import net.minidev.json.JSONObject;
 import net.minidev.json.JSONValue;
 
 /**
- * DateMessageParser extracts timestamp field (specified by 'message.timestamp.name') 
+ * DateMessageParser extracts the timestamp field (specified by 'message.timestamp.name')
  *  and the date pattern (specified by 'message.timestamp.input.pattern')
  * 
  * @see http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html
@@ -39,20 +39,26 @@ import net.minidev.json.JSONValue;
  * 
  */
 public class DateMessageParser extends MessageParser {
+
     private static final Logger LOG = LoggerFactory.getLogger(DateMessageParser.class);
     protected static final String defaultDate = "dt=1970-01-01";
     protected static final String defaultFormatter = "yyyy-MM-dd";
     protected SimpleDateFormat outputFormatter = new SimpleDateFormat(defaultFormatter);
     protected Object inputPattern;
     protected SimpleDateFormat inputFormatter;
-    
+
+    protected final String mDtPrefix;
+
     public DateMessageParser(SecorConfig config) {
         super(config);
+
         TimeZone timeZone = config.getTimeZone();
         inputPattern = mConfig.getMessageTimestampInputPattern();
         inputFormatter = new SimpleDateFormat(inputPattern.toString());
         inputFormatter.setTimeZone(timeZone);
         outputFormatter.setTimeZone(timeZone);
+
+        mDtPrefix = (TimestampedMessageParser.usingDatePrefix(config) == null) ? "" : TimestampedMessageParser.usingDatePrefix(config);
     }
 
     @Override
@@ -65,12 +71,10 @@ public class DateMessageParser extends MessageParser {
             if (fieldValue != null && inputPattern != null) {
                 try {
                     Date dateFormat = inputFormatter.parse(fieldValue.toString());
-                    result[0] = "dt=" + outputFormatter.format(dateFormat);
-                    return result;
+                    result[0] = mDtPrefix + outputFormatter.format(dateFormat);
                 } catch (Exception e) {
-
-                    LOG.warn("Impossible to convert date = {} for the input pattern = {} . Using date default = {}",
-                            fieldValue.toString(), inputPattern.toString(), result[0]);
+                    LOG.warn("Impossible to convert date = {} with the input pattern = {}. Using date default = {}",
+                             fieldValue.toString(), inputPattern.toString(), result[0]);
                 }
             }
         }

--- a/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
@@ -74,15 +74,16 @@ public class DateMessageParserTest extends TestCase {
     @Test
     public void testExtractDateUsingInputPattern() throws Exception {
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.prefix", "dt=")).thenReturn("dt=");
 
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
-        assertEquals("2014-07-30", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+        assertEquals("dt=2014-07-30", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
 
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy/MM/d");
-        assertEquals("2014-10-25", new DateMessageParser(mConfig).extractPartitions(mFormat2)[0]);
+        assertEquals("dt=2014-10-25", new DateMessageParser(mConfig).extractPartitions(mFormat2)[0]);
 
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyyy.MMMMM.dd GGG hh:mm aaa");
-        assertEquals("2001-07-04", new DateMessageParser(mConfig).extractPartitions(mFormat3)[0]);
+        assertEquals("dt=2001-07-04", new DateMessageParser(mConfig).extractPartitions(mFormat3)[0]);
     }
 
     @Test
@@ -113,7 +114,8 @@ public class DateMessageParserTest extends TestCase {
         Mockito.when(mConfig.getMessageTimestampNameSeparator()).thenReturn(".");
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("meta_data.created");
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'hh:mm:ss.SSS'Z'");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.prefix", "dt=")).thenReturn("dt=");
 
-        assertEquals("2016-01-11", new DateMessageParser(mConfig).extractPartitions(mNestedISOFormat)[0]);
+        assertEquals("dt=2016-01-11", new DateMessageParser(mConfig).extractPartitions(mNestedISOFormat)[0]);
     } 
 }

--- a/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
@@ -45,45 +45,44 @@ public class DateMessageParserTest extends TestCase {
     public void setUp() throws Exception {
         mConfig = Mockito.mock(SecorConfig.class);
         Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
-        
+
         byte format1[] = "{\"timestamp\":\"2014-07-30 10:53:20\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
-                .getBytes("UTF-8");
+            .getBytes("UTF-8");
         mFormat1 = new Message("test", 0, 0, null, format1);
 
         byte format2[] = "{\"timestamp\":\"2014/10/25\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
-                .getBytes("UTF-8");
+            .getBytes("UTF-8");
         mFormat2 = new Message("test", 0, 0, null, format2);
 
         byte format3[] = "{\"timestamp\":\"02001.July.04 AD 12:08 PM\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
-                .getBytes("UTF-8");
+            .getBytes("UTF-8");
         mFormat3 = new Message("test", 0, 0, null, format3);
 
         byte invalidDate[] = "{\"timestamp\":\"11111111\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
-                .getBytes("UTF-8");
+            .getBytes("UTF-8");
         mInvalidDate = new Message("test", 0, 0, null, invalidDate);
-        
+
         byte isoFormat[] = "{\"timestamp\":\"2016-01-11T11:50:28.647Z\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
-                .getBytes("UTF-8");
+            .getBytes("UTF-8");
         mISOFormat = new Message("test", 0, 0, null, isoFormat);
-        
+
         byte nestedISOFormat[] = "{\"meta_data\":{\"created\":\"2016-01-11T11:50:28.647Z\"},\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
-                .getBytes("UTF-8");
+            .getBytes("UTF-8");
         mNestedISOFormat = new Message("test", 0, 0, null, nestedISOFormat);
-        
     }
 
     @Test
     public void testExtractDateUsingInputPattern() throws Exception {
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
-        
+
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
-        assertEquals("dt=2014-07-30", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+        assertEquals("2014-07-30", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
 
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy/MM/d");
-        assertEquals("dt=2014-10-25", new DateMessageParser(mConfig).extractPartitions(mFormat2)[0]);
+        assertEquals("2014-10-25", new DateMessageParser(mConfig).extractPartitions(mFormat2)[0]);
 
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyyy.MMMMM.dd GGG hh:mm aaa");
-        assertEquals("dt=2001-07-04", new DateMessageParser(mConfig).extractPartitions(mFormat3)[0]);
+        assertEquals("2001-07-04", new DateMessageParser(mConfig).extractPartitions(mFormat3)[0]);
     }
 
     @Test
@@ -92,20 +91,29 @@ public class DateMessageParserTest extends TestCase {
         // invalid date
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss"); // any pattern
         assertEquals(DateMessageParser.defaultDate, new DateMessageParser(
-                mConfig).extractPartitions(mInvalidDate)[0]);
+            mConfig).extractPartitions(mInvalidDate)[0]);
 
         // invalid pattern
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyy-MM-dd :s");
         assertEquals(DateMessageParser.defaultDate, new DateMessageParser(
-                mConfig).extractPartitions(mFormat1)[0]);
+            mConfig).extractPartitions(mFormat1)[0]);
     }
-    
+
+    @Test
+    public void testDatePrefix() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.prefix", "dt=")).thenReturn("foo");
+
+        assertEquals("foo2014-07-30", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
+    }
+
     @Test
     public void testNestedField() throws Exception {
         Mockito.when(mConfig.getMessageTimestampNameSeparator()).thenReturn(".");
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("meta_data.created");
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'hh:mm:ss.SSS'Z'");
 
-        assertEquals("dt=2016-01-11", new DateMessageParser(mConfig).extractPartitions(mNestedISOFormat)[0]);
+        assertEquals("2016-01-11", new DateMessageParser(mConfig).extractPartitions(mNestedISOFormat)[0]);
     } 
 }


### PR DESCRIPTION
The `DateMessageParser` provides flexibility through timestamp format strings, but then applies a hard-coded `dt=` prefix to the S3 path.  This configuration is actually already support through `partitioner.granularity.date.prefix` in `secor.common.properties` so I updated  `DateMessageParser.extractPartitions()` to leverage the existing functionality.

I also added `testDatePrefix()`, fixed existing tests that were now failing, and made minor formatting changes (e.g. indentation) to conform with the rest of the package.