### PR TITLE
Let DateMessageParser use partitioner.granularity.date.format

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/DateMessageParser.java
@@ -32,18 +32,17 @@ import net.minidev.json.JSONValue;
 /**
  * DateMessageParser extracts the timestamp field (specified by 'message.timestamp.name')
  *  and the date pattern (specified by 'message.timestamp.input.pattern')
- * 
+ *
  * @see http://docs.oracle.com/javase/6/docs/api/java/text/SimpleDateFormat.html
- * 
+ *
  * @author Lucas Zago (lucaszago@gmail.com)
- * 
+ *
  */
 public class DateMessageParser extends MessageParser {
 
     private static final Logger LOG = LoggerFactory.getLogger(DateMessageParser.class);
     protected static final String defaultDate = "dt=1970-01-01";
-    protected static final String defaultFormatter = "yyyy-MM-dd";
-    protected SimpleDateFormat outputFormatter = new SimpleDateFormat(defaultFormatter);
+    protected SimpleDateFormat outputFormatter;
     protected Object inputPattern;
     protected SimpleDateFormat inputFormatter;
 
@@ -56,6 +55,8 @@ public class DateMessageParser extends MessageParser {
         inputPattern = mConfig.getMessageTimestampInputPattern();
         inputFormatter = new SimpleDateFormat(inputPattern.toString());
         inputFormatter.setTimeZone(timeZone);
+
+        outputFormatter = new SimpleDateFormat(TimestampedMessageParser.usingDateFormat(config));
         outputFormatter.setTimeZone(timeZone);
 
         mDtPrefix = TimestampedMessageParser.usingDatePrefix(config);

--- a/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
@@ -62,7 +62,7 @@ public class DateMessageParserTest extends TestCase {
             .getBytes("UTF-8");
         mInvalidDate = new Message("test", 0, 0, null, invalidDate);
 
-        byte isoFormat[] = "{\"timestamp\":\"2016-01-11T11:50:28.647Z\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
+        byte isoFormat[] = "{\"timestamp\":\"2006-01-02T15:04:05Z\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
             .getBytes("UTF-8");
         mISOFormat = new Message("test", 0, 0, null, isoFormat);
 
@@ -84,6 +84,9 @@ public class DateMessageParserTest extends TestCase {
 
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyyy.MMMMM.dd GGG hh:mm aaa");
         assertEquals("dt=2001-07-04", new DateMessageParser(mConfig).extractPartitions(mFormat3)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        assertEquals("dt=2006-01-02", new DateMessageParser(mConfig).extractPartitions(mISOFormat)[0]);
     }
 
     @Test
@@ -117,5 +120,5 @@ public class DateMessageParserTest extends TestCase {
         Mockito.when(mConfig.getString("partitioner.granularity.date.prefix", "dt=")).thenReturn("dt=");
 
         assertEquals("dt=2016-01-11", new DateMessageParser(mConfig).extractPartitions(mNestedISOFormat)[0]);
-    } 
+    }
 }

--- a/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
@@ -38,6 +38,7 @@ public class DateMessageParserTest extends TestCase {
     private Message mFormat3;
     private Message mInvalidDate;
     private Message mISOFormat;
+    private Message mNanosecondISOFormat;
     private Message mNestedISOFormat;
     private OngoingStubbing<String> getTimestamp;
 
@@ -66,6 +67,10 @@ public class DateMessageParserTest extends TestCase {
             .getBytes("UTF-8");
         mISOFormat = new Message("test", 0, 0, null, isoFormat);
 
+        byte nanosecondISOFormat[] = "{\"timestamp\":\"2006-01-02T23:59:59.999999999Z\"}"
+            .getBytes("UTF-8");
+        mNanosecondISOFormat = new Message("test", 0, 0, null, nanosecondISOFormat);
+
         byte nestedISOFormat[] = "{\"meta_data\":{\"created\":\"2016-01-11T11:50:28.647Z\"},\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}"
             .getBytes("UTF-8");
         mNestedISOFormat = new Message("test", 0, 0, null, nestedISOFormat);
@@ -87,6 +92,12 @@ public class DateMessageParserTest extends TestCase {
 
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss'Z'");
         assertEquals("dt=2006-01-02", new DateMessageParser(mConfig).extractPartitions(mISOFormat)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss");
+        assertEquals("dt=2006-01-02", new DateMessageParser(mConfig).extractPartitions(mISOFormat)[0]);
+
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'HH:mm:ss");
+        assertEquals("dt=2006-01-02", new DateMessageParser(mConfig).extractPartitions(mNanosecondISOFormat)[0]);
     }
 
     @Test

--- a/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/DateMessageParserTest.java
@@ -80,6 +80,7 @@ public class DateMessageParserTest extends TestCase {
     public void testExtractDateUsingInputPattern() throws Exception {
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
         Mockito.when(mConfig.getString("partitioner.granularity.date.prefix", "dt=")).thenReturn("dt=");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.format", "yyyy-MM-dd")).thenReturn("yyyy-MM-dd");
 
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
         assertEquals("dt=2014-07-30", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
@@ -103,6 +104,8 @@ public class DateMessageParserTest extends TestCase {
     @Test
     public void testExtractDateWithWrongEntries() throws Exception {
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.format", "yyyy-MM-dd")).thenReturn("yyyy-MM-dd");
+
         // invalid date
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss"); // any pattern
         assertEquals(DateMessageParser.defaultDate, new DateMessageParser(
@@ -119,6 +122,7 @@ public class DateMessageParserTest extends TestCase {
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
         Mockito.when(mConfig.getString("partitioner.granularity.date.prefix", "dt=")).thenReturn("foo");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.format", "yyyy-MM-dd")).thenReturn("yyyy-MM-dd");
 
         assertEquals("foo2014-07-30", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
     }
@@ -129,7 +133,18 @@ public class DateMessageParserTest extends TestCase {
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("meta_data.created");
         Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd'T'hh:mm:ss.SSS'Z'");
         Mockito.when(mConfig.getString("partitioner.granularity.date.prefix", "dt=")).thenReturn("dt=");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.format", "yyyy-MM-dd")).thenReturn("yyyy-MM-dd");
 
         assertEquals("dt=2016-01-11", new DateMessageParser(mConfig).extractPartitions(mNestedISOFormat)[0]);
+    }
+
+    @Test
+    public void testCustomDateFormat() throws Exception {
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getMessageTimestampInputPattern()).thenReturn("yyyy-MM-dd HH:mm:ss");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.prefix", "dt=")).thenReturn("");
+        Mockito.when(mConfig.getString("partitioner.granularity.date.format", "yyyy-MM-dd")).thenReturn("'yr='yyyy'/mo='MM'/dy='dd'/hr='HH");
+
+        assertEquals("yr=2014/mo=07/dy=30/hr=10", new DateMessageParser(mConfig).extractPartitions(mFormat1)[0]);
     }
 }

--- a/src/test/java/com/pinterest/secor/parser/Iso8601ParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/Iso8601ParserTest.java
@@ -38,7 +38,6 @@ public class Iso8601ParserTest extends TestCase {
     private Message mFormat3;
     private Message mFormat4;
     private Message mInvalidDate;
-    private Message mISOFormat;
     private Message mNestedISOFormat;
     private Message mNanosecondISOFormat;
     private Message mMissingDate;


### PR DESCRIPTION
The default 'yyyy-MM-dd' should match the existing behaviour of DateMessageParser.

I'm successfully using this to address #305 plus another side effect of having hive-compatible hourly partitions through DateMessageParser through the following configs:

```
secor.message.parser.class=com.pinterest.secor.parser.DateMessageParser
partitioner.granularity.date.prefix=
message.timestamp.input.pattern=yyyy-MM-dd'T'HH:mm:ss
partitioner.granularity.date.format='yr='yyyy'/mo='MM'/dy='dd'/hr='HH
```

Producing S3 paths like `secor/topicname/yr=2017/mo=02/dy=16/hr=00/1_0_00000000000484693804.gz`.