### PR TITLE
Add SplitFieldMessageParser

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -389,6 +389,10 @@ public class SecorConfig {
         return mProperties.getBoolean("message.timestamp.required");
     }
 
+    public String getMessageSplitFieldName() {
+        return getString("message.split.field.name");
+    }
+
     public int getFinalizerLookbackPeriods() {
         return getInt("secor.finalizer.lookback.periods", 10);
     }

--- a/src/main/java/com/pinterest/secor/parser/SplitByFieldMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/SplitByFieldMessageParser.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
+import org.apache.commons.lang3.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * SplitByFieldMessageParser extracts event type field (specified by 'message.split.field.name')
+ * and timestamp field (specified by 'message.timestamp.name')
+ * from JSON data and splits data into multiple outputs by event type and then partitions each output by date.
+ *
+ * Caution: this parser doesn't support finalization of partitions.
+ */
+public class SplitByFieldMessageParser extends TimestampedMessageParser implements Partitioner
+{
+    private static final Logger LOG = LoggerFactory.getLogger(SplitByFieldMessageParser.class);
+    private final String mSplitFieldName;
+
+    public SplitByFieldMessageParser(SecorConfig config) {
+        super(config);
+
+        mSplitFieldName = config.getMessageSplitFieldName();
+    }
+
+    @Override
+    public long extractTimestampMillis(Message message) throws Exception
+    {
+        throw new UnsupportedOperationException("Unsupported, use extractPartitions method instead");
+    }
+
+    @Override
+    public String[] extractPartitions(Message message) throws Exception
+    {
+        JSONObject jsonObject = (JSONObject) JSONValue.parse(message.getPayload());
+        if (jsonObject == null) {
+            throw new RuntimeException("Failed to parse message as Json object");
+        }
+
+        String eventType = extractEventType(jsonObject);
+        long timestampMillis = extractTimestampMillis(jsonObject);
+
+        String[] timestampPartitions = generatePartitions(timestampMillis, mUsingHourly, mUsingMinutely);
+        return ArrayUtils.addAll(new String[]{eventType}, timestampPartitions);
+    }
+
+    @Override
+    public String[] getFinalizedUptoPartitions(List<Message> lastMessages,
+                                               List<Message> committedMessages) throws Exception
+    {
+        // Partition finalization is not supported
+        return null;
+    }
+
+    @Override
+    public String[] getPreviousPartitions(String[] partition) throws Exception
+    {
+        // Partition finalization is not supported
+        return null;
+    }
+
+    protected String extractEventType(JSONObject jsonObject) {
+        if (!jsonObject.containsKey(mSplitFieldName)) {
+            throw new RuntimeException("Could not find key " + mSplitFieldName + " in Json message");
+        }
+        return jsonObject.get(mSplitFieldName).toString();
+    }
+
+    protected long extractTimestampMillis(JSONObject jsonObject) {
+        Object fieldValue = getJsonFieldValue(jsonObject);
+        if (fieldValue != null) {
+            return toMillis(Double.valueOf(fieldValue.toString()).longValue());
+        } else {
+            throw new RuntimeException("Failed to extract timestamp from the message");
+        }
+    }
+}

--- a/src/main/java/com/pinterest/secor/parser/SplitByFieldMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/SplitByFieldMessageParser.java
@@ -33,8 +33,7 @@ import java.util.List;
  *
  * Caution: this parser doesn't support finalization of partitions.
  */
-public class SplitByFieldMessageParser extends TimestampedMessageParser implements Partitioner
-{
+public class SplitByFieldMessageParser extends TimestampedMessageParser implements Partitioner {
     private static final Logger LOG = LoggerFactory.getLogger(SplitByFieldMessageParser.class);
     private final String mSplitFieldName;
 
@@ -45,14 +44,12 @@ public class SplitByFieldMessageParser extends TimestampedMessageParser implemen
     }
 
     @Override
-    public long extractTimestampMillis(Message message) throws Exception
-    {
+    public long extractTimestampMillis(Message message) throws Exception {
         throw new UnsupportedOperationException("Unsupported, use extractPartitions method instead");
     }
 
     @Override
-    public String[] extractPartitions(Message message) throws Exception
-    {
+    public String[] extractPartitions(Message message) throws Exception {
         JSONObject jsonObject = (JSONObject) JSONValue.parse(message.getPayload());
         if (jsonObject == null) {
             throw new RuntimeException("Failed to parse message as Json object");
@@ -67,17 +64,13 @@ public class SplitByFieldMessageParser extends TimestampedMessageParser implemen
 
     @Override
     public String[] getFinalizedUptoPartitions(List<Message> lastMessages,
-                                               List<Message> committedMessages) throws Exception
-    {
-        // Partition finalization is not supported
-        return null;
+                                               List<Message> committedMessages) throws Exception {
+        throw new UnsupportedOperationException("Partition finalization is not supported");
     }
 
     @Override
-    public String[] getPreviousPartitions(String[] partition) throws Exception
-    {
-        // Partition finalization is not supported
-        return null;
+    public String[] getPreviousPartitions(String[] partitions) throws Exception {
+        throw new UnsupportedOperationException("Partition finalization is not supported");
     }
 
     protected String extractEventType(JSONObject jsonObject) {

--- a/src/test/java/com/pinterest/secor/parser/SplitByFieldMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/SplitByFieldMessageParserTest.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+import junit.framework.TestCase;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONValue;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TimeZone;
+
+@RunWith(PowerMockRunner.class)
+public class SplitByFieldMessageParserTest extends TestCase {
+
+    private SecorConfig mConfig;
+    private Message mMessageWithTypeAndTimestamp;
+    private Message mMessageWithoutTimestamp;
+    private Message mMessageWithoutType;
+
+    @Override
+    public void setUp() throws Exception
+    {
+        mConfig = Mockito.mock(SecorConfig.class);
+        Mockito.when(mConfig.getMessageSplitFieldName()).thenReturn("type");
+        Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
+        Mockito.when(mConfig.getFinalizerDelaySeconds()).thenReturn(3600);
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("UTC"));
+
+        Mockito.when(TimestampedMessageParser.usingDateFormat(mConfig)).thenReturn("yyyy-MM-dd");
+        Mockito.when(TimestampedMessageParser.usingHourFormat(mConfig)).thenReturn("HH");
+        Mockito.when(TimestampedMessageParser.usingMinuteFormat(mConfig)).thenReturn("mm");
+        Mockito.when(TimestampedMessageParser.usingDatePrefix(mConfig)).thenReturn("dt=");
+        Mockito.when(TimestampedMessageParser.usingHourPrefix(mConfig)).thenReturn("hr=");
+        Mockito.when(TimestampedMessageParser.usingMinutePrefix(mConfig)).thenReturn("min=");
+
+        byte messageWithTypeAndTimestamp[] =
+                "{\"type\":\"event1\",\"timestamp\":\"1405911096000\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
+        mMessageWithTypeAndTimestamp = new Message("test", 0, 0, null, messageWithTypeAndTimestamp);
+
+        byte messageWithoutTimestamp[] =
+                "{\"type\":\"event2\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
+        mMessageWithoutTimestamp = new Message("test", 0, 0, null, messageWithoutTimestamp);
+
+        byte messageWithoutType[] =
+                "{\"timestamp\":\"1405911096123\",\"id\":0,\"guid\":\"0436b17b-e78a-4e82-accf-743bf1f0b884\",\"isActive\":false,\"balance\":\"$3,561.87\",\"picture\":\"http://placehold.it/32x32\",\"age\":23,\"eyeColor\":\"green\",\"name\":\"Mercedes Brewer\",\"gender\":\"female\",\"company\":\"MALATHION\",\"email\":\"mercedesbrewer@malathion.com\",\"phone\":\"+1 (848) 471-3000\",\"address\":\"786 Gilmore Court, Brule, Maryland, 3200\",\"about\":\"Quis nostrud Lorem deserunt esse ut reprehenderit aliqua nisi et sunt mollit est. Cupidatat incididunt minim anim eiusmod culpa elit est dolor ullamco. Aliqua cillum eiusmod ullamco nostrud Lorem sit amet Lorem aliquip esse esse velit.\\r\\n\",\"registered\":\"2014-01-14T13:07:28 +08:00\",\"latitude\":47.672012,\"longitude\":102.788623,\"tags\":[\"amet\",\"amet\",\"dolore\",\"eu\",\"qui\",\"fugiat\",\"laborum\"],\"friends\":[{\"id\":0,\"name\":\"Rebecca Hardy\"},{\"id\":1,\"name\":\"Sutton Briggs\"},{\"id\":2,\"name\":\"Dena Campos\"}],\"greeting\":\"Hello, Mercedes Brewer! You have 7 unread messages.\",\"favoriteFruit\":\"strawberry\"}".getBytes("UTF-8");
+        mMessageWithoutType = new Message("test", 0, 0, null, messageWithoutType);
+    }
+
+    @Test
+    public void testExtractTypeAndTimestamp() throws Exception
+    {
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        assertEquals(1405911096000l, jsonMessageParser.extractTimestampMillis((JSONObject) JSONValue.parse(mMessageWithTypeAndTimestamp.getPayload())));
+        assertEquals(1405911096123l, jsonMessageParser.extractTimestampMillis((JSONObject) JSONValue.parse(mMessageWithoutType.getPayload())));
+
+        assertEquals("event1", jsonMessageParser.extractEventType((JSONObject) JSONValue.parse(mMessageWithTypeAndTimestamp.getPayload())));
+        assertEquals("event2", jsonMessageParser.extractEventType((JSONObject) JSONValue.parse(mMessageWithoutTimestamp.getPayload())));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testExtractTimestampMillisExceptionNoTimestamp() throws Exception
+    {
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        // Throws exception if there's no timestamp, for any reason.
+        jsonMessageParser.extractTimestampMillis((JSONObject) JSONValue.parse(mMessageWithoutTimestamp.getPayload()));
+    }
+
+    @Test(expected=ClassCastException.class)
+    public void testExtractTimestampMillisException1() throws Exception
+    {
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        byte emptyBytes1[] = {};
+        jsonMessageParser.extractTimestampMillis((JSONObject) JSONValue.parse(emptyBytes1));
+    }
+
+    @Test(expected=ClassCastException.class)
+    public void testExtractTimestampMillisException2() throws Exception
+    {
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        byte emptyBytes2[] = "".getBytes();
+        jsonMessageParser.extractTimestampMillis((JSONObject) JSONValue.parse(emptyBytes2));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testExtractTimestampMillisExceptionNoType() throws Exception
+    {
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        // Throws exception if there's no timestamp, for any reason.
+        jsonMessageParser.extractEventType((JSONObject) JSONValue.parse(mMessageWithoutType.getPayload()));
+    }
+
+    @Test
+    public void testExtractPartitions() throws Exception
+    {
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        String expectedEventTypePartition = "event1";
+        String expectedDtPartition = "dt=2014-07-21";
+
+        String result[] = jsonMessageParser.extractPartitions(mMessageWithTypeAndTimestamp);
+        assertEquals(2, result.length);
+        assertEquals(expectedEventTypePartition, result[0]);
+        assertEquals(expectedDtPartition, result[1]);
+    }
+
+    @Test
+    public void testExtractHourlyPartitions() throws Exception
+    {
+        Mockito.when(TimestampedMessageParser.usingHourly(mConfig)).thenReturn(true);
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        String expectedEventTypePartition = "event1";
+        String expectedDtPartition = "dt=2014-07-21";
+        String expectedHrPartition = "hr=02";
+
+        String result[] = jsonMessageParser.extractPartitions(mMessageWithTypeAndTimestamp);
+        assertEquals(3, result.length);
+        assertEquals(expectedEventTypePartition, result[0]);
+        assertEquals(expectedDtPartition, result[1]);
+        assertEquals(expectedHrPartition, result[2]);
+    }
+
+    @Test
+    public void testExtractHourlyPartitionsForNonUTCTimezone() throws Exception
+    {
+        Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("IST"));
+        Mockito.when(TimestampedMessageParser.usingHourly(mConfig)).thenReturn(true);
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        String expectedEventTypePartition = "event1";
+        String expectedDtPartition = "dt=2014-07-21";
+        String expectedHrPartition = "hr=08";
+
+        String result[] = jsonMessageParser.extractPartitions(mMessageWithTypeAndTimestamp);
+        assertEquals(3, result.length);
+        assertEquals(expectedEventTypePartition, result[0]);
+        assertEquals(expectedDtPartition, result[1]);
+        assertEquals(expectedHrPartition, result[2]);
+    }
+
+    @Test
+    public void testGetFinalizedUptoPartitions() throws Exception
+    {
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        List<Message> lastMessages = new ArrayList<Message>();
+        lastMessages.add(mMessageWithTypeAndTimestamp);
+        List<Message> committedMessages = new ArrayList<Message>();
+        committedMessages.add(mMessageWithTypeAndTimestamp);
+
+        String uptoPartitions[] = jsonMessageParser.getFinalizedUptoPartitions(lastMessages,
+            committedMessages);
+        assertNull(uptoPartitions);
+
+        String previous[] = jsonMessageParser.getPreviousPartitions(uptoPartitions);
+        assertNull(previous);
+    }
+}

--- a/src/test/java/com/pinterest/secor/parser/SplitByFieldMessageParserTest.java
+++ b/src/test/java/com/pinterest/secor/parser/SplitByFieldMessageParserTest.java
@@ -39,8 +39,7 @@ public class SplitByFieldMessageParserTest extends TestCase {
     private Message mMessageWithoutType;
 
     @Override
-    public void setUp() throws Exception
-    {
+    public void setUp() throws Exception {
         mConfig = Mockito.mock(SecorConfig.class);
         Mockito.when(mConfig.getMessageSplitFieldName()).thenReturn("type");
         Mockito.when(mConfig.getMessageTimestampName()).thenReturn("timestamp");
@@ -68,8 +67,7 @@ public class SplitByFieldMessageParserTest extends TestCase {
     }
 
     @Test
-    public void testExtractTypeAndTimestamp() throws Exception
-    {
+    public void testExtractTypeAndTimestamp() throws Exception {
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
 
         assertEquals(1405911096000l, jsonMessageParser.extractTimestampMillis((JSONObject) JSONValue.parse(mMessageWithTypeAndTimestamp.getPayload())));
@@ -80,26 +78,23 @@ public class SplitByFieldMessageParserTest extends TestCase {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testExtractTimestampMillisExceptionNoTimestamp() throws Exception
-    {
+    public void testExtractTimestampMillisExceptionNoTimestamp() throws Exception {
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
 
         // Throws exception if there's no timestamp, for any reason.
         jsonMessageParser.extractTimestampMillis((JSONObject) JSONValue.parse(mMessageWithoutTimestamp.getPayload()));
     }
 
-    @Test(expected=ClassCastException.class)
-    public void testExtractTimestampMillisException1() throws Exception
-    {
+    @Test(expected = ClassCastException.class)
+    public void testExtractTimestampMillisException1() throws Exception {
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
 
         byte emptyBytes1[] = {};
         jsonMessageParser.extractTimestampMillis((JSONObject) JSONValue.parse(emptyBytes1));
     }
 
-    @Test(expected=ClassCastException.class)
-    public void testExtractTimestampMillisException2() throws Exception
-    {
+    @Test(expected = ClassCastException.class)
+    public void testExtractTimestampMillisException2() throws Exception {
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
 
         byte emptyBytes2[] = "".getBytes();
@@ -107,8 +102,7 @@ public class SplitByFieldMessageParserTest extends TestCase {
     }
 
     @Test(expected = RuntimeException.class)
-    public void testExtractTimestampMillisExceptionNoType() throws Exception
-    {
+    public void testExtractTimestampMillisExceptionNoType() throws Exception {
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
 
         // Throws exception if there's no timestamp, for any reason.
@@ -116,8 +110,7 @@ public class SplitByFieldMessageParserTest extends TestCase {
     }
 
     @Test
-    public void testExtractPartitions() throws Exception
-    {
+    public void testExtractPartitions() throws Exception {
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
 
         String expectedEventTypePartition = "event1";
@@ -130,8 +123,7 @@ public class SplitByFieldMessageParserTest extends TestCase {
     }
 
     @Test
-    public void testExtractHourlyPartitions() throws Exception
-    {
+    public void testExtractHourlyPartitions() throws Exception {
         Mockito.when(TimestampedMessageParser.usingHourly(mConfig)).thenReturn(true);
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
 
@@ -147,8 +139,7 @@ public class SplitByFieldMessageParserTest extends TestCase {
     }
 
     @Test
-    public void testExtractHourlyPartitionsForNonUTCTimezone() throws Exception
-    {
+    public void testExtractHourlyPartitionsForNonUTCTimezone() throws Exception {
         Mockito.when(mConfig.getTimeZone()).thenReturn(TimeZone.getTimeZone("IST"));
         Mockito.when(TimestampedMessageParser.usingHourly(mConfig)).thenReturn(true);
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
@@ -164,9 +155,8 @@ public class SplitByFieldMessageParserTest extends TestCase {
         assertEquals(expectedHrPartition, result[2]);
     }
 
-    @Test
-    public void testGetFinalizedUptoPartitions() throws Exception
-    {
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetFinalizedUptoPartitions() throws Exception {
         SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
 
         List<Message> lastMessages = new ArrayList<Message>();
@@ -174,11 +164,15 @@ public class SplitByFieldMessageParserTest extends TestCase {
         List<Message> committedMessages = new ArrayList<Message>();
         committedMessages.add(mMessageWithTypeAndTimestamp);
 
-        String uptoPartitions[] = jsonMessageParser.getFinalizedUptoPartitions(lastMessages,
-            committedMessages);
-        assertNull(uptoPartitions);
-
-        String previous[] = jsonMessageParser.getPreviousPartitions(uptoPartitions);
-        assertNull(previous);
+        jsonMessageParser.getFinalizedUptoPartitions(lastMessages, committedMessages);
     }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testGetPreviousPartitions() throws Exception {
+        SplitByFieldMessageParser jsonMessageParser = new SplitByFieldMessageParser(mConfig);
+
+        String partitions[] = {"event1", "dt=2014-07-21"};
+        jsonMessageParser.getPreviousPartitions(partitions);
+    }
+
 }


### PR DESCRIPTION
Splits events into multiple output tables by a field value and partitions each table by date.

This pull request tries to address a use-case when Kafka topic contains events of multiple types with different schema and we would like to store events of each type as a separate table in the final storage. All events have common header with a discriminator field (event type) and timestamp.

Unfortunately secor doesn't seem to account for this use case. And I had to cut some corners to minimize changes to secor codebase:
 * the new parser doesn't support partition finalization
 * date format is hardcoded.  A composite like approach to plugin existing date parser would cause performance penalty since it leads to deserialization of json message two times.

I completely understand if you reject the pull request because of those shortcomings. I just don't see a nicer way to implement that use case within bounds of current secor design.
And any feedback would be much appreciated.

