### PR TITLE
MetricCollector component for ingesting secor metrics into a monitoring service

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -377,3 +377,7 @@ secor.upload.minute_mark=0
 # File age per topic and per partition is checked against secor.max.file.age.seconds by looking at
 # the youngest file when true or at the oldest file when false.
 secor.file.age.youngest=true
+
+# Class that manages metric collection.
+# Sending metrics to Ostrich is the default implementation.
+secor.monitoring.metrics.collector.class=com.pinterest.secor.monitoring.OstrichMetricCollector

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -565,4 +565,8 @@ public class SecorConfig {
     public String getThriftProtocolClass() {
         return mProperties.getString("secor.thrift.protocol.class");
     }
+
+    public String getMetricsCollectorClass() {
+        return mProperties.getString("secor.monitoring.metrics.collector.class");
+    }
 }

--- a/src/main/java/com/pinterest/secor/monitoring/MetricCollector.java
+++ b/src/main/java/com/pinterest/secor/monitoring/MetricCollector.java
@@ -1,0 +1,47 @@
+package com.pinterest.secor.monitoring;
+
+/**
+ * Component which may be used to post metrics.
+ *
+ * All methods should be non-blocking and do not throw exceptions.
+ */
+public interface MetricCollector {
+    /**
+     * Increments the specified counter by one.
+     * Convenience method equivalent to {@link #increment(String, int, String)}.
+     *
+     * @param label metric name
+     * @param topic a tag which describes which topic this data is collected for
+     */
+    void increment(String label, String topic);
+
+    /**
+     * Adjusts the specified counter by a given delta
+     *
+     * @param label metric name
+     * @param delta the amount to adjust the counter by
+     * @param topic a tag which describes which topic this data is collected for
+     */
+    void increment(String label, int delta, String topic);
+
+    /**
+     * Used to track the statistical distribution of a set of values.
+     * <p>
+     * Metrics are collected by tracking the count, min, max, mean (average), and a simple bucket-based histogram of
+     * the distribution. This distribution can be used to determine median, 90th percentile, etc.
+     *
+     * @param label metric name
+     * @param value the value to be incorporated in the distribution
+     * @param topic a tag which describes which topic this data is collected for
+     */
+    void metric(String label, double value, String topic);
+
+    /**
+     * Records the latest fixed value for the specified named gauge.
+     *
+     * @param label gauge name
+     * @param value the new reading of the gauge
+     * @param topic a tag which describes which topic this data is collected for
+     */
+    void gauge(String label, double value, String topic);
+}

--- a/src/main/java/com/pinterest/secor/monitoring/OstrichMetricCollector.java
+++ b/src/main/java/com/pinterest/secor/monitoring/OstrichMetricCollector.java
@@ -1,0 +1,25 @@
+package com.pinterest.secor.monitoring;
+
+import com.twitter.ostrich.stats.Stats;
+
+public class OstrichMetricCollector implements MetricCollector {
+    @Override
+    public void increment(String label, String topic) {
+        Stats.incr(label);
+    }
+
+    @Override
+    public void increment(String label, int delta, String topic) {
+        Stats.incr(label, delta);
+    }
+
+    @Override
+    public void metric(String label, double value, String topic) {
+        Stats.addMetric(label, (int) value);
+    }
+
+    @Override
+    public void gauge(String label, double value, String topic) {
+        Stats.setGauge(label, value);
+    }
+}

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -21,6 +21,7 @@ import com.pinterest.secor.common.*;
 import com.pinterest.secor.io.FileReader;
 import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.io.KeyValue;
+import com.pinterest.secor.monitoring.MetricCollector;
 import com.pinterest.secor.util.CompressionUtil;
 import com.pinterest.secor.util.IdUtil;
 import com.pinterest.secor.util.ReflectionUtil;
@@ -43,6 +44,7 @@ public class Uploader {
     private static final Logger LOG = LoggerFactory.getLogger(Uploader.class);
 
     protected SecorConfig mConfig;
+    protected MetricCollector mMetricCollector;
     protected OffsetTracker mOffsetTracker;
     protected FileRegistry mFileRegistry;
     protected ZookeeperConnector mZookeeperConnector;
@@ -57,24 +59,25 @@ public class Uploader {
      * @param offsetTracker Tracker of the current offset of topics partitions
      * @param fileRegistry Registry of log files on a per-topic and per-partition basis
      * @param uploadManager Manager of the physical upload of log files to the remote repository
+     * @param metricCollector component that ingest metrics into monitoring system
      */
     public void init(SecorConfig config, OffsetTracker offsetTracker, FileRegistry fileRegistry,
-                     UploadManager uploadManager) {
+                     UploadManager uploadManager, MetricCollector metricCollector) {
         init(config, offsetTracker, fileRegistry, uploadManager,
-                new ZookeeperConnector(config));
+                new ZookeeperConnector(config), metricCollector);
     }
 
     // For testing use only.
     public void init(SecorConfig config, OffsetTracker offsetTracker, FileRegistry fileRegistry,
                      UploadManager uploadManager,
-                     ZookeeperConnector zookeeperConnector) {
+                     ZookeeperConnector zookeeperConnector, MetricCollector metricCollector) {
         mConfig = config;
         mOffsetTracker = offsetTracker;
         mFileRegistry = fileRegistry;
         mUploadManager = uploadManager;
         mZookeeperConnector = zookeeperConnector;
         mTopicFilter = mConfig.getKafkaTopicUploadAtMinuteMarkFilter();
-
+        mMetricCollector = metricCollector;
     }
 
     protected void uploadFiles(TopicPartition topicPartition) throws Exception {
@@ -110,6 +113,8 @@ public class Uploader {
                 mFileRegistry.deleteTopicPartition(topicPartition);
                 mZookeeperConnector.setCommittedOffsetCount(topicPartition, lastSeenOffset + 1);
                 mOffsetTracker.setCommittedOffsetCount(topicPartition, lastSeenOffset + 1);
+
+                mMetricCollector.increment("uploader.file_uploads.count", paths.size(), topicPartition.getTopic());
             }
         } finally {
             mZookeeperConnector.unlock(lockPath);

--- a/src/main/java/com/pinterest/secor/util/ReflectionUtil.java
+++ b/src/main/java/com/pinterest/secor/util/ReflectionUtil.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,17 +16,17 @@
  */
 package com.pinterest.secor.util;
 
-import org.apache.hadoop.io.compress.CompressionCodec;
-
 import com.pinterest.secor.common.LogFilePath;
 import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.io.FileReader;
 import com.pinterest.secor.io.FileReaderWriterFactory;
 import com.pinterest.secor.io.FileWriter;
+import com.pinterest.secor.monitoring.MetricCollector;
 import com.pinterest.secor.parser.MessageParser;
 import com.pinterest.secor.transformer.MessageTransformer;
 import com.pinterest.secor.uploader.UploadManager;
 import com.pinterest.secor.uploader.Uploader;
+import org.apache.hadoop.io.compress.CompressionCodec;
 
 /**
  * ReflectionUtil implements utility methods to construct objects of classes
@@ -118,7 +118,7 @@ public class ReflectionUtil {
      * @throws Exception
      */
     private static FileReaderWriterFactory createFileReaderWriterFactory(String className,
-            SecorConfig config) throws Exception {
+                                                                         SecorConfig config) throws Exception {
         Class<?> clazz = Class.forName(className);
         if (!FileReaderWriterFactory.class.isAssignableFrom(clazz)) {
             throw new IllegalArgumentException(String.format("The class '%s' is not assignable to '%s'.",
@@ -168,7 +168,7 @@ public class ReflectionUtil {
             throws Exception {
         return createFileReaderWriterFactory(className, config).BuildFileReader(logFilePath, codec);
     }
-    
+
     /**
      * Create a MessageTransformer from it's fully qualified class name. The
      * class passed in by name must be assignable to MessageTransformers and have
@@ -177,7 +177,7 @@ public class ReflectionUtil {
      * config.
      *
      * See the secor.message.transformer.class config option.
-     * 
+     *
      * @param className
      * @param config
      * @return
@@ -193,5 +193,32 @@ public class ReflectionUtil {
         }
         return (MessageTransformer) clazz.getConstructor(SecorConfig.class)
                 .newInstance(config);
+    }
+
+    /**
+     * Create an MetricCollector from its fully qualified class name.
+     * <p>
+     * The class passed in by name must be assignable to MetricCollector.
+     * See the secor.monitoring.metrics.collector.class config option.
+     *
+     * @param className The class name of a subclass of MetricCollector
+     * @return a MetricCollector with the runtime type of the class passed by name
+     * @throws ClassNotFoundException if class with the {@code className} is not found in classpath
+     * @throws IllegalAccessException if the class or its nullary
+     *                                constructor is not accessible.
+     * @throws InstantiationException if this {@code Class} represents an abstract class,
+     *                                an interface, an array class, a primitive type, or void;
+     *                                or if the class has no nullary constructor;
+     *                                or if the instantiation fails for some other reason.
+     */
+    public static MetricCollector createMetricCollector(String className)
+            throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        Class<?> clazz = Class.forName(className);
+        if (!MetricCollector.class.isAssignableFrom(clazz)) {
+            throw new IllegalArgumentException(String.format("The class '%s' is not assignable to '%s'.",
+                    className, MetricCollector.class.getName()));
+        }
+
+        return (MetricCollector) clazz.newInstance();
     }
 }

--- a/src/test/config/secor.test.monitoring.properties
+++ b/src/test/config/secor.test.monitoring.properties
@@ -1,0 +1,1 @@
+secor.monitoring.metrics.collector.class=com.pinterest.secor.monitoring.OstrichMetricCollector

--- a/src/test/java/com/pinterest/secor/common/SecorConfigTest.java
+++ b/src/test/java/com/pinterest/secor/common/SecorConfigTest.java
@@ -1,16 +1,15 @@
 package com.pinterest.secor.common;
 
+import com.pinterest.secor.protobuf.Messages.UnitTestMessage1;
+import com.pinterest.secor.protobuf.Messages.UnitTestMessage2;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.junit.Test;
 
-import com.pinterest.secor.protobuf.Messages.UnitTestMessage1;
-import com.pinterest.secor.protobuf.Messages.UnitTestMessage2;
-
 import java.net.URL;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class SecorConfigTest {
 
@@ -48,5 +47,16 @@ public class SecorConfigTest {
         assertEquals(2, messageClassPerTopic.size());
         assertEquals(UnitTestMessage1.class.getName(), messageClassPerTopic.get("mytopic1"));
         assertEquals(UnitTestMessage2.class.getName(), messageClassPerTopic.get("mytopic2"));
-    }    
+    }
+
+    @Test
+    public void shouldReadMetricCollectorConfiguration() throws ConfigurationException {
+
+        URL configFile = Thread.currentThread().getContextClassLoader().getResource("secor.test.monitoring.properties");
+        PropertiesConfiguration properties = new PropertiesConfiguration(configFile);
+
+        SecorConfig secorConfig = new SecorConfig(properties);
+
+        assertEquals("com.pinterest.secor.monitoring.OstrichMetricCollector", secorConfig.getMetricsCollectorClass());
+    }
 }

--- a/src/test/java/com/pinterest/secor/monitoring/OstrichMetricCollectorTest.java
+++ b/src/test/java/com/pinterest/secor/monitoring/OstrichMetricCollectorTest.java
@@ -1,0 +1,52 @@
+package com.pinterest.secor.monitoring;
+
+import com.twitter.ostrich.stats.Stats;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Stats.class})
+public class OstrichMetricCollectorTest {
+    private OstrichMetricCollector metricCollector = new OstrichMetricCollector();
+
+    @Before
+    public void setUp() throws Exception {
+        PowerMockito.mockStatic(Stats.class);
+    }
+
+    @Test
+    public void incrementByOne() throws Exception {
+        metricCollector.increment("expectedLabel", "ignored");
+
+        PowerMockito.verifyStatic();
+        Stats.incr("expectedLabel");
+    }
+
+    @Test
+    public void increment() throws Exception {
+        metricCollector.increment("expectedLabel", 42, "ignored");
+
+        PowerMockito.verifyStatic();
+        Stats.incr("expectedLabel", 42);
+    }
+
+    @Test
+    public void metric() throws Exception {
+        metricCollector.metric("expectedLabel", 42.0, "ignored");
+
+        PowerMockito.verifyStatic();
+        Stats.addMetric("expectedLabel", 42);
+    }
+
+    @Test
+    public void gauge() throws Exception {
+        metricCollector.gauge("expectedLabel", 4.2, "ignored");
+
+        PowerMockito.verifyStatic();
+        Stats.setGauge("expectedLabel", 4.2);
+    }
+}

--- a/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
+++ b/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
@@ -20,6 +20,7 @@ import com.pinterest.secor.common.*;
 import com.pinterest.secor.io.FileReader;
 import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.io.KeyValue;
+import com.pinterest.secor.monitoring.MetricCollector;
 import com.pinterest.secor.util.FileUtil;
 import com.pinterest.secor.util.IdUtil;
 
@@ -55,7 +56,7 @@ public class UploaderTest extends TestCase {
                             FileRegistry fileRegistry,
                             UploadManager uploadManager,
                             ZookeeperConnector zookeeperConnector) {
-            init(config, offsetTracker, fileRegistry, uploadManager, zookeeperConnector);
+            init(config, offsetTracker, fileRegistry, uploadManager, zookeeperConnector, Mockito.mock(MetricCollector.class));
             mReader = Mockito.mock(FileReader.class);
         }
 

--- a/src/test/java/com/pinterest/secor/util/ReflectionUtilTest.java
+++ b/src/test/java/com/pinterest/secor/util/ReflectionUtilTest.java
@@ -5,9 +5,9 @@
  * The ASF licenses this file to You under the Apache License, Version 2.0
  * (the "License"); you may not use this file except in compliance with
  * the License.  You may obtain a copy of the License at
- *
- *    http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,10 +18,14 @@ package com.pinterest.secor.util;
 
 import com.pinterest.secor.common.LogFilePath;
 import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.monitoring.MetricCollector;
+import com.pinterest.secor.monitoring.OstrichMetricCollector;
 import com.pinterest.secor.parser.MessageParser;
 import org.apache.commons.configuration.PropertiesConfiguration;
-import org.junit.Test;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Test;
 
 public class ReflectionUtilTest {
 
@@ -31,12 +35,12 @@ public class ReflectionUtilTest {
     @Before
     public void setUp() throws Exception {
         PropertiesConfiguration properties = new PropertiesConfiguration();
-        properties.addProperty("message.timestamp.name","");
-        properties.addProperty("message.timestamp.name.separator","");
-        properties.addProperty("secor.offsets.prefix","offset=");
+        properties.addProperty("message.timestamp.name", "");
+        properties.addProperty("message.timestamp.name.separator", "");
+        properties.addProperty("secor.offsets.prefix", "offset=");
         mSecorConfig = new SecorConfig(properties);
         mLogFilePath = new LogFilePath("/foo", "/foo/bar/baz/1_1_1");
-        
+
     }
 
     @Test
@@ -69,5 +73,25 @@ public class ReflectionUtilTest {
         // assignable to MessageParser
         ReflectionUtil.createFileWriter("java.lang.Object",
                 mLogFilePath, null, mSecorConfig);
+    }
+
+    @Test
+    public void testCreateMetricsCollector() throws Exception {
+        MetricCollector metricCollector = ReflectionUtil.createMetricCollector("com.pinterest.secor.monitoring.OstrichMetricCollector");
+
+        Assert.assertNotNull(metricCollector);
+        Assert.assertThat(metricCollector, CoreMatchers.instanceOf(OstrichMetricCollector.class));
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testCreateMetricsCollectorClassNotFound() throws Exception {
+        ReflectionUtil.createMetricCollector("com.example.foo");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateMetricsCollectorNotAssignable() throws Exception {
+        // Try to create a message parser using an existent and available class, but one not
+        // assignable to MessageParser
+        ReflectionUtil.createMetricCollector("java.lang.Object");
     }
 }


### PR DESCRIPTION
The component is pluggable, you can configure ingestion of metrics to any monitoring system by implementing MetricCollector interface.
By default metrics are sent to Ostrich, statistic library bundled into secor.

Metrics:
- consumer.message_size_bytes - records distribution of message sizes processed by secor (min/max/avg/count)
- consumer.throughput_bytes - total number of bytes processed by secor
- consumer.message_errors.count - number of errors during message parsing
- uploader.file_uploads.count - number of files uploaded

We are going to implement DataDogCollector for our set up. However, I tried to make the interface as abstract as possible, so potentially connector to any metric collection system can be implemented.