### PR TITLE
Bump log4j library to 1.2.17 to support EnhancedPatternLayout

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.15</version>
+            <version>1.2.17</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.sun.jmx</groupId>


### PR DESCRIPTION
This is a PR for issue https://github.com/pinterest/secor/issues/227

We've been running Secor bundling with 1.2.17 for around one year and had no problem with it.