### PR TITLE
Updates the 0.10 kafka client to the latest version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -620,7 +620,7 @@
                 <dependency>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka_2.10</artifactId>
-                    <version>0.10.0.1</version>
+                    <version>0.10.2.0</version>
                     <exclusions>
                         <exclusion>
                             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Thanks for this great project!

Per the release notes, this new 0.10.2 client is capable of detecting any kafka
versions between 0.10.0.x and 0.10.2.x. This change allows users
of intermediate kafka versions (e.g. 0.10.1 or 0.10.2) to use secor
without any other changes.

[Relevant release notes](http://kafka.apache.org/documentation.html#upgrade_1020_notable)