### PR TITLE
Bump Parquet and Expose Configuration Variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <maven.compiler.target>1.6</maven.compiler.target>
         <encoding>UTF-8</encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <parquet.version>1.8.1</parquet.version>
+        <parquet.version>1.9.0</parquet.version>
     </properties>
 
     <distributionManagement>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -381,3 +381,20 @@ secor.file.age.youngest=true
 # Class that manages metric collection.
 # Sending metrics to Ostrich is the default implementation.
 secor.monitoring.metrics.collector.class=com.pinterest.secor.monitoring.OstrichMetricCollector
+
+# Row group size in bytes for Parquet writers. Specifies how much data will be buffered in memory before flushing a
+# block to disk. Larger values allow for larger column chinks which makes it possible to do larger sequential IO.
+# Should be aligned with HDFS blocks. Defaults to 128MB in Parquet 1.9.
+parquet.block.size=134217728
+
+# Page group size in bytes for Parquet writers. Indivisible unit for columnar data. Smaller data pages allow for more
+# fine grained reading but have higher space overhead. Defaults to 1MB in Parquet 1.9.
+parquet.page.size=1048576
+
+# Enable or disable dictionary encoding for Parquet writers. The dictionary encoding builds a dictionary of values
+# encountered in a given column. Defaults to true in Parquet 1.9.
+parquet.enable.dictionary=true
+
+# Enable or disable validation for Parquet writers. Validates records written against the schema. Defaults to false in
+# Parquet 1.9.
+parquet.validation=false

--- a/src/main/java/com/pinterest/secor/io/impl/ProtobufParquetFileReaderWriterFactory.java
+++ b/src/main/java/com/pinterest/secor/io/impl/ProtobufParquetFileReaderWriterFactory.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.parquet.hadoop.ParquetReader;
-import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.proto.ProtoParquetReader;
 import org.apache.parquet.proto.ProtoParquetWriter;
@@ -19,6 +18,7 @@ import com.pinterest.secor.io.FileReader;
 import com.pinterest.secor.io.FileReaderWriterFactory;
 import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.io.KeyValue;
+import com.pinterest.secor.util.ParquetUtil;
 import com.pinterest.secor.util.ProtobufUtil;
 
 /**
@@ -30,8 +30,18 @@ public class ProtobufParquetFileReaderWriterFactory implements FileReaderWriterF
 
     private ProtobufUtil protobufUtil;
 
+    protected final int blockSize;
+    protected final int pageSize;
+    protected final boolean enableDictionary;
+    protected final boolean validating;
+
     public ProtobufParquetFileReaderWriterFactory(SecorConfig config) {
         protobufUtil = new ProtobufUtil(config);
+
+        blockSize = ParquetUtil.getParquetBlockSize(config);
+        pageSize = ParquetUtil.getParquetPageSize(config);
+        enableDictionary = ParquetUtil.getParquetEnableDictionary(config);
+        validating = ParquetUtil.getParquetValidation(config);
     }
 
     @Override
@@ -81,7 +91,7 @@ public class ProtobufParquetFileReaderWriterFactory implements FileReaderWriterF
                     .fromCompressionCodec(codec != null ? codec.getClass() : null);
             topic = logFilePath.getTopic();
             writer = new ProtoParquetWriter<Message>(path, protobufUtil.getMessageClass(topic), codecName,
-                    ParquetWriter.DEFAULT_BLOCK_SIZE, ParquetWriter.DEFAULT_PAGE_SIZE);
+                    blockSize, pageSize, enableDictionary, validating);
         }
 
         @Override

--- a/src/main/java/com/pinterest/secor/io/impl/ThriftParquetFileReaderWriterFactory.java
+++ b/src/main/java/com/pinterest/secor/io/impl/ThriftParquetFileReaderWriterFactory.java
@@ -17,6 +17,7 @@ import com.pinterest.secor.io.FileReader;
 import com.pinterest.secor.io.FileReaderWriterFactory;
 import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.io.KeyValue;
+import com.pinterest.secor.util.ParquetUtil;
 import com.pinterest.secor.util.ThriftUtil;
 
 /**
@@ -30,8 +31,18 @@ public class ThriftParquetFileReaderWriterFactory implements FileReaderWriterFac
 
     private ThriftUtil thriftUtil;
 
+    protected final int blockSize;
+    protected final int pageSize;
+    protected final boolean enableDictionary;
+    protected final boolean validating;
+
     public ThriftParquetFileReaderWriterFactory(SecorConfig config) {
         thriftUtil = new ThriftUtil(config);
+
+        blockSize = ParquetUtil.getParquetBlockSize(config);
+        pageSize = ParquetUtil.getParquetPageSize(config);
+        enableDictionary = ParquetUtil.getParquetEnableDictionary(config);
+        validating = ParquetUtil.getParquetValidation(config);
     }
 
     @Override
@@ -92,7 +103,8 @@ public class ThriftParquetFileReaderWriterFactory implements FileReaderWriterFac
             Path path = new Path(logFilePath.getLogFilePath());
             CompressionCodecName codecName = CompressionCodecName.fromCompressionCodec(codec != null ? codec.getClass() : null);
             topic = logFilePath.getTopic();
-            writer = new ThriftParquetWriter(path, thriftUtil.getMessageClass(topic), codecName);
+            writer = new ThriftParquetWriter(path, thriftUtil.getMessageClass(topic), codecName,
+                    blockSize, pageSize, enableDictionary, validating);
         }
 
         @Override

--- a/src/main/java/com/pinterest/secor/util/ParquetUtil.java
+++ b/src/main/java/com/pinterest/secor/util/ParquetUtil.java
@@ -1,0 +1,22 @@
+package com.pinterest.secor.util;
+
+import com.pinterest.secor.common.SecorConfig;
+import org.apache.parquet.hadoop.ParquetWriter;
+
+public class ParquetUtil {
+    public static int getParquetBlockSize(SecorConfig config) {
+        return config.getInt("parquet.block.size", ParquetWriter.DEFAULT_BLOCK_SIZE);
+    }
+
+    public static int getParquetPageSize(SecorConfig config) {
+        return config.getInt("parquet.page.size", ParquetWriter.DEFAULT_PAGE_SIZE);
+    }
+
+    public static boolean getParquetEnableDictionary(SecorConfig config) {
+        return config.getBoolean("parquet.enable.dictionary", ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED);
+    }
+
+    public static boolean getParquetValidation(SecorConfig config) {
+        return config.getBoolean("parquet.validation", ParquetWriter.DEFAULT_IS_VALIDATING_ENABLED);
+    }
+}

--- a/src/test/java/com/pinterest/secor/io/impl/ProtobufParquetFileReaderWriterFactoryTest.java
+++ b/src/test/java/com/pinterest/secor/io/impl/ProtobufParquetFileReaderWriterFactoryTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertArrayEquals;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.parquet.hadoop.ParquetWriter;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
@@ -33,7 +35,9 @@ import com.pinterest.secor.io.FileReader;
 import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.io.KeyValue;
 import com.pinterest.secor.protobuf.Messages.UnitTestMessage3;
+import com.pinterest.secor.util.ParquetUtil;
 import com.pinterest.secor.util.ReflectionUtil;
+
 
 import junit.framework.TestCase;
 
@@ -54,6 +58,15 @@ public class ProtobufParquetFileReaderWriterFactoryTest extends TestCase {
         Mockito.when(config.getProtobufMessageClassPerTopic()).thenReturn(classPerTopic);
         Mockito.when(config.getFileReaderWriterFactory())
                 .thenReturn(ProtobufParquetFileReaderWriterFactory.class.getName());
+        Mockito.when(ParquetUtil.getParquetBlockSize(config))
+                .thenReturn(ParquetWriter.DEFAULT_BLOCK_SIZE);
+        Mockito.when(ParquetUtil.getParquetPageSize(config))
+                .thenReturn(ParquetWriter.DEFAULT_PAGE_SIZE);
+        Mockito.when(ParquetUtil.getParquetEnableDictionary(config))
+                .thenReturn(ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED);
+        Mockito.when(ParquetUtil.getParquetValidation(config))
+                .thenReturn(ParquetWriter.DEFAULT_IS_VALIDATING_ENABLED);
+
 
         LogFilePath tempLogFilePath = new LogFilePath(Files.createTempDir().toString(), "test-pb-topic",
                 new String[] { "part-1" }, 0, 1, 23232, ".log");

--- a/src/test/java/com/pinterest/secor/io/impl/ThriftParquetFileReaderWriterFactoryTest.java
+++ b/src/test/java/com/pinterest/secor/io/impl/ThriftParquetFileReaderWriterFactoryTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertArrayEquals;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.parquet.hadoop.ParquetWriter;
+
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TCompactProtocol;
@@ -36,6 +38,7 @@ import com.pinterest.secor.io.FileReader;
 import com.pinterest.secor.io.FileWriter;
 import com.pinterest.secor.io.KeyValue;
 import com.pinterest.secor.thrift.UnitTestMessage;
+import com.pinterest.secor.util.ParquetUtil;
 import com.pinterest.secor.util.ReflectionUtil;
 
 import junit.framework.TestCase;
@@ -58,7 +61,16 @@ public class ThriftParquetFileReaderWriterFactoryTest extends TestCase {
         Mockito.when(config.getFileReaderWriterFactory())
                 .thenReturn(ThriftParquetFileReaderWriterFactory.class.getName());
         Mockito.when(config.getThriftProtocolClass())
-        .thenReturn(TCompactProtocol.class.getName());        
+        .thenReturn(TCompactProtocol.class.getName());
+        Mockito.when(ParquetUtil.getParquetBlockSize(config))
+                .thenReturn(ParquetWriter.DEFAULT_BLOCK_SIZE);
+        Mockito.when(ParquetUtil.getParquetPageSize(config))
+                .thenReturn(ParquetWriter.DEFAULT_PAGE_SIZE);
+        Mockito.when(ParquetUtil.getParquetEnableDictionary(config))
+                .thenReturn(ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED);
+        Mockito.when(ParquetUtil.getParquetValidation(config))
+                .thenReturn(ParquetWriter.DEFAULT_IS_VALIDATING_ENABLED);
+
 
         LogFilePath tempLogFilePath = new LogFilePath(Files.createTempDir().toString(), "test-pb-topic",
                 new String[] { "part-1" }, 0, 1, 23232, ".log");


### PR DESCRIPTION
See discussion at #328 

Exposes row group size, page size, dictionary encoding, and validation as configurable options to pass to the parquet writer. Bumps Parquet to 1.9.0 which implements more memory efficient dictionary encoding, among other enhancements.