### PR TITLE
Stores Kafka message timestamp as part of the encoded information

### DIFF
--- a/src/main/java/com/pinterest/secor/io/KeyValue.java
+++ b/src/main/java/com/pinterest/secor/io/KeyValue.java
@@ -19,21 +19,23 @@ package com.pinterest.secor.io;
 /**
  * Generic Object used to read next message from various file reader
  * implementations
- * 
+ *
  * @author Praveen Murugesan (praveen@uber.com)
  *
  */
 public class KeyValue {
-	
+
 	private final long mOffset;
 	private final byte[] mKafkaKey;
 	private final byte[] mValue;
+	private final long mTimestamp;
 
 	// constructor
 	public KeyValue(long offset, byte[] value) {
 		this.mOffset = offset;
 		this.mKafkaKey = new byte[0];
 		this.mValue = value;
+		this.mTimestamp = -1;
 	}
 
 	// constructor
@@ -41,6 +43,15 @@ public class KeyValue {
 		this.mOffset = offset;
 		this.mKafkaKey = kafkaKey;
 		this.mValue = value;
+		this.mTimestamp = -1;
+	}
+
+	// constructor
+	public KeyValue(long offset, byte[] kafkaKey, byte[] value, long timestamp) {
+		this.mOffset = offset;
+		this.mKafkaKey = kafkaKey;
+		this.mValue = value;
+		this.mTimestamp = timestamp;
 	}
 
 	public long getOffset() {
@@ -50,9 +61,20 @@ public class KeyValue {
 	public byte[] getKafkaKey() {
 		return this.mKafkaKey;
 	}
-	
+
 	public byte[] getValue() {
 		return this.mValue;
 	}
 
+	public long getTimestamp() {
+		return this.mTimestamp;
+	}
+
+	public boolean hasKafkaKey() {
+		return this.mKafkaKey != null && this.mKafkaKey.length != 0;
+	}
+
+	public boolean hasTimestamp(){
+		return this.mTimestamp != -1;
+	}
 }

--- a/src/main/java/com/pinterest/secor/writer/MessageWriter.java
+++ b/src/main/java/com/pinterest/secor/writer/MessageWriter.java
@@ -92,7 +92,7 @@ public class MessageWriter {
         LogFilePath path = new LogFilePath(mLocalPrefix, mGeneration, offset, message,
         		mFileExtension);
         FileWriter writer = mFileRegistry.getOrCreateWriter(path, mCodec);
-        writer.write(new KeyValue(message.getOffset(), message.getKafkaKey(), message.getPayload()));
+        writer.write(new KeyValue(message.getOffset(), message.getKafkaKey(), message.getPayload(), message.getTimestamp()));
         LOG.debug("appended message {} to file {}.  File length {}",
                   message, path, writer.getLength());
     }

--- a/src/test/java/com/pinterest/secor/io/impl/MessagePackSequenceFileReaderWriterFactoryTest.java
+++ b/src/test/java/com/pinterest/secor/io/impl/MessagePackSequenceFileReaderWriterFactoryTest.java
@@ -43,8 +43,14 @@ public class MessagePackSequenceFileReaderWriterFactoryTest {
         FileWriter fileWriter = factory.BuildFileWriter(tempLogFilePath, null);
         KeyValue kv1 = (new KeyValue(23232, new byte[]{44, 55, 66, 77, 88}, new byte[]{23, 45, 40 ,10, 122}));
         KeyValue kv2 = (new KeyValue(23233, new byte[]{2, 3, 4, 5}));
+        KeyValue kv3 =  (new KeyValue(23234, new byte[]{44, 55, 66, 77, 88}, new byte[]{23, 45, 40 ,10, 122}, 1496318250));
+        KeyValue kv4 =  (new KeyValue(23235, null, new byte[]{23, 45, 40 ,10, 122}, 1496318250));
+
         fileWriter.write(kv1);
         fileWriter.write(kv2);
+        fileWriter.write(kv3);
+        fileWriter.write(kv4);
+
         fileWriter.close();
         FileReader fileReader = factory.BuildFileReader(tempLogFilePath, null);
 
@@ -56,7 +62,17 @@ public class MessagePackSequenceFileReaderWriterFactoryTest {
         assertEquals(kv2.getOffset(), kvout.getOffset());
         assertArrayEquals(kv2.getKafkaKey(), kvout.getKafkaKey());
         assertArrayEquals(kv2.getValue(), kvout.getValue());
-    }
+        kvout = fileReader.next();
+        assertEquals(kv3.getOffset(), kvout.getOffset());
+        assertArrayEquals(kv3.getKafkaKey(), kvout.getKafkaKey());
+        assertArrayEquals(kv3.getValue(), kvout.getValue());
+        assertEquals(kv3.getTimestamp(), kvout.getTimestamp());
+        kvout = fileReader.next();
+        assertEquals(kv4.getOffset(), kvout.getOffset());
+        assertArrayEquals(new byte[0], kvout.getKafkaKey());
+        assertArrayEquals(kv4.getValue(), kvout.getValue());
+        assertEquals(kv4.getTimestamp(), kvout.getTimestamp());
 
+    }
 
 }


### PR DESCRIPTION
This PR allows to store Kafka messages timestamp information as part of the encoded MessagePack record. 

This has been discussed here https://github.com/pinterest/secor/issues/342