### PR TITLE
pom.xml: bump aws sdk to 1.11.160

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,12 +100,12 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.10.68</version>
+            <version>1.11.160</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-sts</artifactId>
-            <version>1.10.68</version>
+            <version>1.11.160</version>
         </dependency>
         <dependency>
             <groupId>net.java.dev.jets3t</groupId>


### PR DESCRIPTION
Helps avoid issues with some S3-compatible software like minio, see https://github.com/minio/minio/issues/3672

Tested with:

```console
% grep '^aw's secor.properties 
aws.access.key=minio
aws.secret.key=miniostorage
aws.role=
aws.proxy.isEnabled=false
aws.sse.type=
aws.sse.customer.key=
aws.sse.kms.key=
aws.region=us-east-1
aws.endpoint=http://localhost:5000
aws.client.pathstyleaccess=true
```