### PR TITLE
Modified README.md for current default active profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Edit `src/main/config/*.properties` files to specify parameters describing the e
 
 ##### Create and install jars
 ```sh
-# By default this will install the "release" (Kafka 0.8 profile)
+# By default this will install the "release" (Kafka 0.10 profile)
 mvn package
 mkdir ${SECOR_INSTALL_DIR} # directory to place Secor binaries in.
 tar -zxvf target/secor-0.1-SNAPSHOT-bin.tar.gz -C ${SECOR_INSTALL_DIR}
 
-# To use the Kafka 0.10 client you should use the kafka-0.10-dev profile
-mvn -Pkafka-0.10-dev package
+# To use the Kafka 0.8 client you should use the kafka-0.8-dev profile
+mvn -Pkafka-0.8-dev package
 ```
 
 ##### Run tests (optional)


### PR DESCRIPTION
We have `kafka-0.10-dev` as default active build profile, so README should be updated.