### PR TITLE
Handle empty topics for the ProgressMonitor

### DIFF
--- a/src/main/java/com/pinterest/secor/common/KafkaClient.java
+++ b/src/main/java/com/pinterest/secor/common/KafkaClient.java
@@ -31,6 +31,7 @@ import kafka.javaapi.TopicMetadataRequest;
 import kafka.javaapi.TopicMetadataResponse;
 import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.message.MessageAndOffset;
+import org.apache.kafka.common.protocol.Errors;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,7 +132,7 @@ public class KafkaClient {
             consumer.close();
             int errorCode = response.errorCode(topicPartition.getTopic(), topicPartition.getPartition());
 
-            if (errorCode == 1) {
+            if (errorCode == Errors.OFFSET_OUT_OF_RANGE.code()) {
               throw new MessageDoesNotExistException();
             } else {
               throw new RuntimeException("Error fetching offset data. Reason: " + errorCode);

--- a/src/main/java/com/pinterest/secor/common/KafkaClient.java
+++ b/src/main/java/com/pinterest/secor/common/KafkaClient.java
@@ -229,6 +229,7 @@ public class KafkaClient {
           // That is no an exceptional situation - in fact it can be normal if
           // the topic being consumed by Secor has a low volume. So in that
           // case, simply return null
+          LOG.warn("no committed message for topic {} partition {}", topicPartition.getTopic(), topicPartition.getPartition());
           return null;
         } finally {
             if (consumer != null) {

--- a/src/main/java/com/pinterest/secor/tools/ProgressMonitor.java
+++ b/src/main/java/com/pinterest/secor/tools/ProgressMonitor.java
@@ -207,8 +207,14 @@ public class ProgressMonitor {
                     assert committedOffset <= lastOffset: Long.toString(committedOffset) + " <= " +
                         lastOffset;
 
-                    long offsetLag = lastOffset - committedOffset;
-                    long timestampMillisLag = lastTimestampMillis - committedTimestampMillis;
+                    long offsetLag = 0L;
+                    long timestampMillisLag = 0L;
+
+                    if (committedMessage != null) {
+                        offsetLag = lastOffset - committedOffset;
+                        timestampMillisLag = lastTimestampMillis - committedTimestampMillis;
+                    }
+
                     Map<String, String> tags = ImmutableMap.of(
                             Stat.STAT_KEYS.TOPIC.getName(), topic,
                             Stat.STAT_KEYS.PARTITION.getName(), Integer.toString(partition),

--- a/src/main/java/com/pinterest/secor/tools/ProgressMonitor.java
+++ b/src/main/java/com/pinterest/secor/tools/ProgressMonitor.java
@@ -193,6 +193,7 @@ public class ProgressMonitor {
                 long committedTimestampMillis = -1;
                 if (committedMessage == null) {
                     LOG.warn("no committed message found in topic {} partition {}", topic, partition);
+                    continue;
                 } else {
                     committedOffset = committedMessage.getOffset();
                     committedTimestampMillis = getTimestamp(committedMessage);
@@ -207,14 +208,8 @@ public class ProgressMonitor {
                     assert committedOffset <= lastOffset: Long.toString(committedOffset) + " <= " +
                         lastOffset;
 
-                    long offsetLag = 0L;
-                    long timestampMillisLag = 0L;
-
-                    if (committedMessage != null) {
-                        offsetLag = lastOffset - committedOffset;
-                        timestampMillisLag = lastTimestampMillis - committedTimestampMillis;
-                    }
-
+                    long offsetLag = lastOffset - committedOffset;
+                    long timestampMillisLag = lastTimestampMillis - committedTimestampMillis;
                     Map<String, String> tags = ImmutableMap.of(
                             Stat.STAT_KEYS.TOPIC.getName(), topic,
                             Stat.STAT_KEYS.PARTITION.getName(), Integer.toString(partition),


### PR DESCRIPTION
If a `TopicPartition` has had all of its messages on the broker compacted away, when you call `KafakaClient.getCommittedMessage` with that `TopicPartition` a `RuntimeException` was raised. This is due to the obvious fact that `getCommittedMessage` is attempting to return a `Message`, however there is no `Message` to return from the broker.

This is not, I would argue, an _exceptional_ situation. If the topic has low volume or an aggressive compaction configuration, often times the log on the broker will be empty. This generally does not cause problems, except in the case of #189, where the `ProgressMonitor` will crash on the error.

This is not ideal, as actual progress is totally caught up. So this change attempts to address this situation through two changes:

1. Change `KafakaClient.getCommittedMessage` to return `null` if there is no message found.
2. Update `ProgressMonitor.getStats` to record a `0` lag value if no committed message was found.

I've left some self-review notes below please take a look.

I'll also add that I didn't see any existing tests for the `ProgressMonitor` or `KafakaClient` so I did not add any. Let me know if you think it would be worth adding some however.