### PR TITLE
Use official Docker image "openjdk" instead of "java"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8
+FROM openjdk:8
 
 RUN mkdir -p /opt/secor
 ADD target/secor-*-bin.tar.gz /opt/secor/


### PR DESCRIPTION
The official Java image is deprecated and has no longer recieved any updates since Dec 31 2016. As the Java image has always been built around OpenJDK, using the official Dockerhub OpenJDK image is a logical replacement.

See comments re deprecation at: https://hub.docker.com/r/library/java/