### PR TITLE
JsonORCFileReaderWriterFactory crashes for null/non-existing values #369

### DIFF
--- a/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
+++ b/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
@@ -218,7 +218,7 @@ public class VectorColumnFiller {
             JsonElement field = data.get(fieldNames.get(c));
             if (field == null) {
                 batch.cols[c].noNulls = false;
-                batch.cols[c].isNull[0] = true;
+                batch.cols[c].isNull[rowIndex] = true;
             } else {
                 converters[c].convert(field, batch.cols[c], rowIndex);
             }


### PR DESCRIPTION
In my tests batch size was always 1 and my previous fix was to set index value to 0, correct fix should be to use "rowIndex" parameter as index.