### PR TITLE
Allow use of AWS session token

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -29,6 +29,8 @@ cloud.service=S3
 # Leave empty if using IAM role-based authentication with s3a filesystem.
 aws.access.key=
 aws.secret.key=
+# Session token only required if using temporary S3 access keys
+aws.session.token=
 aws.role=
 
 # Optional Proxy Setting. Set to true to enable proxy

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -273,6 +273,10 @@ public class SecorConfig {
         return getString("aws.secret.key");
     }
 
+    public String getAwsSessionToken() {
+        return getString("aws.session.token");
+    }
+
     public String getAwsEndpoint() {
         return getString("aws.endpoint");
     }

--- a/src/main/java/com/pinterest/secor/uploader/S3UploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/S3UploadManager.java
@@ -16,6 +16,7 @@
  */
 package com.pinterest.secor.uploader;
 
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
@@ -81,6 +82,7 @@ public class S3UploadManager extends UploadManager {
 
         final String accessKey = mConfig.getAwsAccessKey();
         final String secretKey = mConfig.getAwsSecretKey();
+        final String sessionToken = mConfig.getAwsSessionToken();
         final String endpoint = mConfig.getAwsEndpoint();
         final String region = mConfig.getAwsRegion();
         final String awsRole = mConfig.getAwsRole();
@@ -107,7 +109,11 @@ public class S3UploadManager extends UploadManager {
         } else {
             provider = new AWSCredentialsProvider() {
                 public AWSCredentials getCredentials() {
-                    return new BasicAWSCredentials(accessKey, secretKey);
+                    if (sessionToken.isEmpty()) {
+                        return new BasicAWSCredentials(accessKey, secretKey);
+                    } else {
+                        return new BasicSessionCredentials(accessKey, secretKey, sessionToken);
+                    }
                 }
                 public void refresh() {}
             };

--- a/src/main/scripts/docker-entrypoint.sh
+++ b/src/main/scripts/docker-entrypoint.sh
@@ -53,6 +53,9 @@ fi
 if [[ ! -z "$AWS_SECRET_KEY" ]]; then
 	SECOR_CONFIG="$SECOR_CONFIG -Daws.secret.key=$AWS_SECRET_KEY"
 fi
+if [[ ! -z "$AWS_SESSION_TOKEN" ]]; then
+	SECOR_CONFIG="$SECOR_CONFIG -Daws.session.token=$AWS_SESSION_TOKEN"
+fi
 if [[ ! -z "$SECOR_S3_BUCKET" ]]; then
     SECOR_CONFIG="$SECOR_CONFIG -Dsecor.s3.bucket=$SECOR_S3_BUCKET"
     echo "secor.s3.bucket=$SECOR_S3_BUCKET"


### PR DESCRIPTION
Small change to allow use of session token for S3 authentication.

This is required if you are using temporary access keys when running locally.