### PR TITLE
Added a build profile for use with kafka version 0.10.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
                 <dependency>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka_2.10</artifactId>
-                    <version>0.10.0.1</version>
+                    <version>0.10.2.0</version>
                     <exclusions>
                         <exclusion>
                             <groupId>org.slf4j</groupId>
@@ -640,6 +640,25 @@
         </profile>
         <profile>
             <id>kafka-0.10-dev</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka_2.10</artifactId>
+                    <version>0.10.2.0</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-simple</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>kafka-0.10.0.1</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>

--- a/pom.xml
+++ b/pom.xml
@@ -598,7 +598,7 @@
                 <dependency>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka_2.10</artifactId>
-                    <version>0.10.2.0</version>
+                    <version>0.10.0.1</version>
                     <exclusions>
                         <exclusion>
                             <groupId>org.slf4j</groupId>
@@ -647,7 +647,7 @@
                 <dependency>
                     <groupId>org.apache.kafka</groupId>
                     <artifactId>kafka_2.10</artifactId>
-                    <version>0.10.2.0</version>
+                    <version>0.10.0.1</version>
                     <exclusions>
                         <exclusion>
                             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
the default of 0.10.2.0 is not working with our 0.10.0.1 kafka cluster. It produces java.nio.channels.ClosedChannelException exceptions whenever messages are added to be consumed

If there is a better solution than this, I am happy to use it.