### PR TITLE
Bump libthrift to 0.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
         <dependency>
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
-            <version>0.5.0</version>
+            <version>0.10.0</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>


### PR DESCRIPTION
In order to use newly generated thrift classes we need to bump to a newer version.