### PR TITLE
Fix ORC writer with ZLIB compression

### DIFF
--- a/src/main/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactory.java
+++ b/src/main/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactory.java
@@ -10,13 +10,13 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.Lz4Codec;
 import org.apache.hadoop.io.compress.SnappyCodec;
+import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.apache.orc.impl.ZlibCodec;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONWriter;
 import org.slf4j.Logger;
@@ -181,7 +181,10 @@ public class JsonORCFileReaderWriterFactory implements FileReaderWriterFactory {
             return CompressionKind.LZ4;
         else if (codec instanceof SnappyCodec)
             return CompressionKind.SNAPPY;
-        else if (codec instanceof ZlibCodec)
+        // although GZip and ZLIB are not same thing
+        // there is no better named codec for this case,
+        // use hadoop Gzip codec to enable ORC ZLIB compression
+        else if (codec instanceof GzipCodec)
             return CompressionKind.ZLIB;
         else
             return CompressionKind.NONE;


### PR DESCRIPTION
The current version uses org.apache.orc.impl.ZlibCodec to enable ZLIB compression for ORC, but it's impossible to use it as secor fails to create it if it's specified in the secor.compression.codec property.
The PR uses org.apache.hadoop.io.compress.GzipCodec to trigger ORC ZLIB compression which is used usually for other formats.