### PR TITLE
Don't swallow exception when trying to read bad config file

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -47,7 +47,7 @@ public class SecorConfig {
             try {
                 properties = new PropertiesConfiguration(configProperty);
             } catch (ConfigurationException e) {
-                throw new RuntimeException("Error loading configuration from " + configProperty);
+                throw new RuntimeException("Error loading configuration from " + configProperty, e);
             }
 
             for (final Map.Entry<Object, Object> entry : systemProperties.entrySet()) {


### PR DESCRIPTION
When throwing an exception after failing to read the configuration file, don't ignore the underlying exception.