### PR TITLE
Fixes usage of Gsuploadermanager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,15 +321,14 @@
             <version>3.0.2</version>
         </dependency>
         <dependency>
-            <groupId>com.google.apis</groupId>
-            <artifactId>google-api-services-storage</artifactId>
-            <version>v1-rev40-1.20.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava-jdk5</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>com.google.cloud</groupId>
+            <artifactId>google-cloud-storage</artifactId>
+            <version>1.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auth</groupId>
+            <artifactId>google-auth-library-appengine</artifactId>
+            <version>0.9.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/src/main/java/com/pinterest/secor/uploader/GsUploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/GsUploadManager.java
@@ -125,6 +125,13 @@ public class GsUploadManager extends UploadManager {
                 throw new RuntimeException("Failed to load Google credentials : " + credentialsPath, e);
             }
 
+            // Depending on the environment that provides the default credentials (e.g. Compute Engine, App
+            // Engine), the credentials may require us to specify the scopes we need explicitly.
+            // Check for this case, and inject the scope if required.
+            if (credential.createScopedRequired()) {
+                credential = credential.createScoped(StorageScopes.all());
+            }
+
             mStorageService = new Storage.Builder(httpTransport, JSON_FACTORY,
                     setHttpBackoffTimeout(credential, connectTimeoutMs, readTimeoutMs))
                     .setApplicationName("com.pinterest.secor")

--- a/src/main/java/com/pinterest/secor/uploader/GsUploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/GsUploadManager.java
@@ -18,7 +18,6 @@ import com.google.api.services.storage.StorageScopes;
 import com.google.api.services.storage.model.StorageObject;
 import com.pinterest.secor.common.LogFilePath;
 import com.pinterest.secor.common.SecorConfig;
-import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,8 +29,6 @@ import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.Date;
-import java.text.SimpleDateFormat;
 
 /**
  * Manages uploads to Google Cloud Storage using the Storage class from the Google API SDK.


### PR DESCRIPTION
Issues found while trying to use Gsuploadermanager as `secor.upload.manager.class` and running secor on kubernetes / GKE. 