### PR TITLE
Enhancement in container runtime + Dockerfile issue with SSL certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:8
-
+# https://github.com/docker-library/openjdk/issues/145#issuecomment-334561903
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894979
+RUN rm /etc/ssl/certs/java/cacerts ; update-ca-certificates -f
 RUN mkdir -p /opt/secor
 ADD target/secor-*-bin.tar.gz /opt/secor/
 

--- a/src/main/scripts/docker-entrypoint.sh
+++ b/src/main/scripts/docker-entrypoint.sh
@@ -103,5 +103,5 @@ DEFAULT_CLASSPATH="*:lib/*"
 CLASSPATH=${CLASSPATH:-$DEFAULT_CLASSPATH}
 
 java -Xmx${JVM_MEMORY:-512m} $JAVA_OPTS -ea -Dsecor_group=${SECOR_GROUP:-partition} -Dlog4j.configuration=file:./${LOG4J_CONFIGURATION:-log4j.docker.properties} \
-        -Dconfig=secor.prod.partition.properties $SECOR_CONFIG \
+        -Dconfig=${CONFIG_FILE:-secor.prod.partition.properties} $SECOR_CONFIG \
         -cp $CLASSPATH com.pinterest.secor.main.ConsumerMain


### PR DESCRIPTION
Allow to set -Dconfig flag via env CONFIG_FILE on startup.  …
This allows us refer to another CONFIG_FILE during startup.  I've kept the
default which refer to `secor.prod.partition.properties` if not set.

In kubernetes we can simply control which config is used by volume mounting the
correct config map, but this keeps backwards compatibility and provides the
possibilities to:

 * All environments in one config map
 * A given environment in one config map.


Fixes missing cacerts bug currently happening in openjdk:8 image  …
This patch can be reverted once Debian Stable (Stretch) has backported the fix
mentioned in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894979 .
See docker-library/openjdk#145 (comment)