### PR TITLE
Provide a standard log4j docker-warn properties file

### DIFF
--- a/src/main/config/log4j.docker-warn.properties
+++ b/src/main/config/log4j.docker-warn.properties
@@ -1,0 +1,8 @@
+# log4j logging configuration.
+
+# root logger.
+log4j.rootLogger=WARN, CONSOLE
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [%t] (%c) %-5p %m%n


### PR DESCRIPTION
So we can easily referer to this configuration file from upstream.
This is used while prototyping deploying secor with kubernetes.