### PR TITLE
Allow to change MAIN_CLASS for entrypoint

### DIFF
--- a/src/main/scripts/docker-entrypoint.sh
+++ b/src/main/scripts/docker-entrypoint.sh
@@ -104,4 +104,4 @@ CLASSPATH=${CLASSPATH:-$DEFAULT_CLASSPATH}
 
 java -Xmx${JVM_MEMORY:-512m} $JAVA_OPTS -ea -Dsecor_group=${SECOR_GROUP:-partition} -Dlog4j.configuration=file:./${LOG4J_CONFIGURATION:-log4j.docker.properties} \
         -Dconfig=${CONFIG_FILE:-secor.prod.partition.properties} $SECOR_CONFIG \
-        -cp $CLASSPATH com.pinterest.secor.main.ConsumerMain
+        -cp $CLASSPATH ${SECOR_MAIN_CLASS:-com.pinterest.secor.main.ConsumerMain}


### PR DESCRIPTION
This allows us to configure the main class during startup.  Currently used for
running 2 containers in a kubernetes pod, where the other one is the monitor
process.

Defaults to com.pinterest.secor.main.ConsumerMain which was old behaviour