### PR TITLE
Remove dotDash ./ so we can use fully qualified paths

### DIFF
--- a/src/main/scripts/docker-entrypoint.sh
+++ b/src/main/scripts/docker-entrypoint.sh
@@ -130,6 +130,6 @@ cd /opt/secor
 DEFAULT_CLASSPATH="*:lib/*"
 CLASSPATH=${CLASSPATH:-$DEFAULT_CLASSPATH}
 
-java -Xmx${JVM_MEMORY:-512m} $JAVA_OPTS -ea -Dsecor_group=${SECOR_GROUP:-partition} -Dlog4j.configuration=file:./${LOG4J_CONFIGURATION:-log4j.docker.properties} \
+java -Xmx${JVM_MEMORY:-512m} $JAVA_OPTS -ea -Dsecor_group=${SECOR_GROUP:-partition} -Dlog4j.configuration=file:${LOG4J_CONFIGURATION:-log4j.docker.properties} \
         -Dconfig=${CONFIG_FILE:-secor.prod.partition.properties} $SECOR_CONFIG \
         -cp $CLASSPATH ${SECOR_MAIN_CLASS:-com.pinterest.secor.main.ConsumerMain}


### PR DESCRIPTION
Avoid prefixing file with ./ so we can actually use fully qualified paths.
This is required in helm charts, which is gonna get an update soon™. 