### PR TITLE
Update source to work with kafka-1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_install:
 # Also dependencies gets installed by other targets anyway.
 install: true  
 script:
+  - make dependency_tree
   - make unit
   - make integration
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - MVN_PROFILE=kafka-0.8.2.1
 jdk:
   - openjdk8
-  - oraclejdk8
 before_install:
   - wget https://github.com/s3tools/s3cmd/archive/v$S3CMD.tar.gz -O /tmp/s3cmd.tar.gz
   - tar -xzf /tmp/s3cmd.tar.gz -C $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,12 @@ addons:
   hosts:
     - test-bucket.localhost
 env:
-  - PATH=$PATH:$HOME/.s3cmd SECOR_LOCAL_S3=true S3CMD=2.0.1
+  global:
+    - PATH=$PATH:$HOME/.s3cmd SECOR_LOCAL_S3=true S3CMD=2.0.1
+  matrix:
+    - MVN_PROFILE=kafka-0.11-1.0.0
+    - MVN_PROFILE=kafka-0.10.0.1
+    - MVN_PROFILE=kafka-0.8-dev
 jdk:
   - openjdk8
   - oraclejdk8
@@ -13,6 +18,10 @@ before_install:
   - mv $HOME/s3cmd-$S3CMD $HOME/.s3cmd
   - cd $HOME/.s3cmd && python setup.py install --user && cd -
   - gem install fakes3 -v 1.2.1
+# Skip install
+## As we require to explicit set a kafka/library profile to build with, and travis just does mvn install -DskipTests=true -Dmaven.javadoc.skiop0true -B -V without using MVN_OPTS
+# Also dependencies gets installed by other targets anyway.
+install: true  
 script:
   - make unit
   - make integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ env:
   global:
     - PATH=$PATH:$HOME/.s3cmd SECOR_LOCAL_S3=true S3CMD=2.0.1
   matrix:
-    - MVN_PROFILE=kafka-0.11-1.0.0
-    - MVN_PROFILE=kafka-0.10.0.1
-    - MVN_PROFILE=kafka-0.8-dev
+    - MVN_PROFILE=kafka-1.0.0
+    - MVN_PROFILE=kafka-0.10.2.0
+    - MVN_PROFILE=kafka-0.8.2.1
 jdk:
   - openjdk8
   - oraclejdk8

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ CONTAINERS=$(shell ls containers)
 build:
 	@mvn package $(MVN_OPTS) -P $(MVN_PROFILE)
 
+dependency_tree:
+	@mvn dependency:tree -P $(MVN_PROFILE)
+
 unit:
 	@mvn test -P $(MVN_PROFILE)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CONFIG=src/main/config
 TEST_HOME=/tmp/secor_test
 TEST_CONFIG=src/test/config
 JAR_FILE=target/secor-*-SNAPSHOT-bin.tar.gz
-MVN_PROFILE?=kafka-0.11-1.0.0
+MVN_PROFILE?=kafka-0.10.2.0
 MVN_OPTS=-DskipTests=true -Dmaven.javadoc.skip=true -P $(MVN_PROFILE)
 CONTAINERS=$(shell ls containers)
 

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,15 @@ CONFIG=src/main/config
 TEST_HOME=/tmp/secor_test
 TEST_CONFIG=src/test/config
 JAR_FILE=target/secor-*-SNAPSHOT-bin.tar.gz
-MVN_OPTS=-DskipTests=true -Dmaven.javadoc.skip=true
+MVN_PROFILE?=kafka-0.11-1.0.0
+MVN_OPTS=-DskipTests=true -Dmaven.javadoc.skip=true -P $(MVN_PROFILE)
 CONTAINERS=$(shell ls containers)
 
 build:
-	@mvn package $(MVN_OPTS)
+	@mvn package $(MVN_OPTS) -P $(MVN_PROFILE)
 
 unit:
-	@mvn test
+	@mvn test -P $(MVN_PROFILE)
 
 integration: build
 	@rm -rf $(TEST_HOME)

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,0 +1,22 @@
+# Secor developer notes
+
+
+## Dependencies
+
+### Bumping to new default kafka version 
+
+* Make new profile if it doesn't exist, matching kafka version as id tag.
+* Ensure the new profile is the only one active pr default with `activation->activeByDefault`
+* Change release profile to have the same stuff in it's profile. (used for
+  buildservers who signs artifacts with GPG and attach javadocs and pushes to
+public M2 repository..)
+* Update MVN_PROFILE in `Makefile`
+* Update .travis and add it into the matrix, so CI runs tests for your kafka
+  version profile.
+
+Profit.
+
+### scala versions
+
+Ensure you check `mvn dependency:tree` and ensure you don't pull in libraries
+compiled with different scala versions. This is bad.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Edit `src/main/config/*.properties` files to specify parameters describing the e
 
 ##### Create and install jars
 ```sh
-# By default this will install the "release" (Kafka 0.10 profile)
-mvn package
+# See pom.xml and select from valid profiles listed for your environment!
+mvn package -P <kafka_profile and matching scal version>
 mkdir ${SECOR_INSTALL_DIR} # directory to place Secor binaries in.
 tar -zxvf target/secor-0.1-SNAPSHOT-bin.tar.gz -C ${SECOR_INSTALL_DIR}
 
@@ -41,7 +41,7 @@ mvn -Pkafka-0.8-dev package
 ##### Run tests (optional)
 ```sh
 cd ${SECOR_INSTALL_DIR}
-./scripts/run_tests.sh
+MVN_PROFILE=<profile> ./scripts/run_tests.sh
 ```
 
 ##### Run Secor

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ Edit `src/main/config/*.properties` files to specify parameters describing the e
 
 ##### Create and install jars
 ```sh
-# By default this will install the "kafka-0.11-1.0.0" (kafka 1.0.0, scala 2.11)
+# By default this will install the "kafka-0.10.2.0" profile
 mvn package
 mkdir ${SECOR_INSTALL_DIR} # directory to place Secor binaries in.
 tar -zxvf target/secor-0.1-SNAPSHOT-bin.tar.gz -C ${SECOR_INSTALL_DIR}
 
-# To use the Kafka 0.10.2.0 kafka libraries with scala 2.10 , use the release profile
-mvn -Prelease
+# To use the Kafka 1.0.0 kafka libraries with scala 2.11
+mvn -Pkafka-1.0.0
 ```
 
 ##### Run tests (optional)

--- a/README.md
+++ b/README.md
@@ -29,18 +29,20 @@ Edit `src/main/config/*.properties` files to specify parameters describing the e
 
 ##### Create and install jars
 ```sh
-# See pom.xml and select from valid profiles listed for your environment!
-mvn package -P <kafka_profile and matching scal version>
+# By default this will install the "kafka-0.11-1.0.0" (kafka 1.0.0, scala 2.11)
+mvn package
 mkdir ${SECOR_INSTALL_DIR} # directory to place Secor binaries in.
 tar -zxvf target/secor-0.1-SNAPSHOT-bin.tar.gz -C ${SECOR_INSTALL_DIR}
 
-# To use the Kafka 0.8 client you should use the kafka-0.8-dev profile
-mvn -Pkafka-0.8-dev package
+# To use the Kafka 0.10.2.0 kafka libraries with scala 2.10 , use the release profile
+mvn -Prelease
 ```
 
 ##### Run tests (optional)
 ```sh
 cd ${SECOR_INSTALL_DIR}
+./scripts/run_tests.sh
+# OR:
 MVN_PROFILE=<profile> ./scripts/run_tests.sh
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -693,6 +693,9 @@
             </dependencies>
         </profile>
         <profile>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <id>kafka-0.11-1.0.0</id>
             <dependencyManagement>
                 <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,26 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
+    <dependencyManagement>
+        <dependencies>
+            <!-- Azure pulls in 2.6 while kafka-2.11 pulls in 2.9.1 -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.9.5</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.9.5</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.9.5</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <repositories>
         <repository>
@@ -258,11 +278,6 @@
             <version>0.10.0</version>
         </dependency>
         <dependency>
-            <groupId>com.twitter</groupId>
-            <artifactId>ostrich_2.10</artifactId>
-            <version>9.2.1</version>
-        </dependency>
-        <dependency>
             <groupId>com.twitter.common.zookeeper</groupId>
             <artifactId>lock</artifactId>
             <version>0.0.7</version>
@@ -323,17 +338,12 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>1.14.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.auth</groupId>
-            <artifactId>google-auth-library-appengine</artifactId>
-            <version>0.9.0</version>
+            <version>1.31.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-storage</artifactId>
-            <version>4.0.0</version>
+            <version>7.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.orc</groupId>
@@ -619,6 +629,15 @@
                     </plugin>
                 </plugins>
             </build>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-scala_2.10</artifactId>
+                        <version>2.9.5</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.kafka</groupId>
@@ -630,6 +649,11 @@
                             <artifactId>slf4j-simple</artifactId>
                         </exclusion>
                     </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.twitter</groupId>
+                    <artifactId>ostrich_2.10</artifactId>
+                    <version>9.2.1</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -661,32 +685,48 @@
                         </exclusion>
                     </exclusions>
                 </dependency>
+                <dependency>
+                    <groupId>com.twitter</groupId>
+                    <artifactId>ostrich_2.10</artifactId>
+                    <version>9.2.1</version>
+                 </dependency>
             </dependencies>
         </profile>
         <profile>
-            <id>kafka-0.10-dev</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
+            <id>kafka-0.11-1.0.0</id>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-scala_2.11</artifactId>
+                        <version>2.9.5</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.kafka</groupId>
-                    <artifactId>kafka_2.10</artifactId>
-                    <version>0.10.2.0</version>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>org.slf4j</groupId>
-                            <artifactId>slf4j-simple</artifactId>
-                        </exclusion>
-                    </exclusions>
+                    <artifactId>kafka_2.11</artifactId>
+                    <version>1.0.0</version>
                 </dependency>
+                <dependency>
+                    <groupId>com.twitter</groupId>
+                    <artifactId>ostrich_2.11</artifactId>
+                    <version>9.27.0</version>
+              </dependency>
             </dependencies>
         </profile>
         <profile>
             <id>kafka-0.10.0.1</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-scala_2.10</artifactId>
+                        <version>2.9.5</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.kafka</groupId>
@@ -698,6 +738,11 @@
                             <artifactId>slf4j-simple</artifactId>
                         </exclusion>
                     </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.twitter</groupId>
+                    <artifactId>ostrich_2.10</artifactId>
+                    <version>9.2.1</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/pom.xml
+++ b/pom.xml
@@ -585,6 +585,7 @@
     <profiles>
         <profile>
             <id>release</id>
+            <!-- Matches kafka-0.10.2.0 , just this one includes gpg signing, javadoc etc -->
             <build>
                 <plugins>
                     <plugin>
@@ -658,7 +659,7 @@
             </dependencies>
         </profile>
         <profile>
-            <id>kafka-0.8-dev</id>
+            <id>kafka-0.8.2.1</id>
             <build>
                 <plugins>
                     <plugin>
@@ -693,10 +694,7 @@
             </dependencies>
         </profile>
         <profile>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <id>kafka-0.11-1.0.0</id>
+            <id>kafka-1.0.0</id>
             <dependencyManagement>
                 <dependencies>
                     <dependency>
@@ -717,6 +715,39 @@
                     <artifactId>ostrich_2.11</artifactId>
                     <version>9.27.0</version>
               </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>kafka-0.10.2.0</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.fasterxml.jackson.module</groupId>
+                        <artifactId>jackson-module-scala_2.10</artifactId>
+                        <version>2.9.5</version>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.kafka</groupId>
+                    <artifactId>kafka_2.10</artifactId>
+                    <version>0.10.2.0</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-simple</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>com.twitter</groupId>
+                    <artifactId>ostrich_2.10</artifactId>
+                    <version>9.2.1</version>
+                </dependency>
             </dependencies>
         </profile>
         <profile>

--- a/src/main/java/com/pinterest/secor/common/OstrichAdminService.java
+++ b/src/main/java/com/pinterest/secor/common/OstrichAdminService.java
@@ -16,6 +16,7 @@
  */
 package com.pinterest.secor.common;
 
+import java.util.Arrays;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
@@ -25,9 +26,11 @@ import com.twitter.util.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import scala.Option;
+import scala.collection.JavaConversions;
 import scala.collection.Map$;
 import scala.collection.immutable.List;
 import scala.collection.immutable.List$;
+import scala.collection.mutable.Buffer;
 import scala.util.matching.Regex;
 
 /**
@@ -53,7 +56,8 @@ public class OstrichAdminService {
             Option.<String>empty(),
             List$.MODULE$.<Regex>empty(),
             Map$.MODULE$.<String, CustomHttpHandler>empty(),
-            List.<Duration>fromArray(defaultLatchIntervals)
+            JavaConversions
+                .asScalaBuffer(Arrays.asList(defaultLatchIntervals)).toList()
         );
         RuntimeEnvironment runtimeEnvironment = new RuntimeEnvironment(this);
         adminServiceFactory.apply(runtimeEnvironment);

--- a/src/main/java/com/pinterest/secor/parser/SplitByFieldMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/SplitByFieldMessageParser.java
@@ -59,7 +59,7 @@ public class SplitByFieldMessageParser extends TimestampedMessageParser implemen
         long timestampMillis = extractTimestampMillis(jsonObject);
 
         String[] timestampPartitions = generatePartitions(timestampMillis, mUsingHourly, mUsingMinutely);
-        return ArrayUtils.addAll(new String[]{eventType}, timestampPartitions);
+        return (String[]) ArrayUtils.addAll(new String[]{eventType}, timestampPartitions);
     }
 
     @Override

--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -22,7 +22,7 @@
 #
 # To run the test:
 #     cd ${OPTIMUS}/secor
-#     mvn package
+#     mvn package -P <kafka-profile with matching scala versions>
 #     mkdir /tmp/test
 #     cd /tmp/test
 #     tar -zxvf ~/git/optimus/secor/target/secor-0.2-SNAPSHOT-bin.tar.gz
@@ -149,6 +149,10 @@ stop_kafka_server() {
 }
 
 start_secor() {
+    if [ "$MVN_PROFILE" = "kafka-0.8-dev" ];then
+      echo "Detected kafka 0,8 profile, need to run with Kafka8 timestamp class.."
+      ADDITIONAL_OPTS="${ADDITIONAL_OPTS} -Dkafka.message.timestamp.className=com.pinterest.secor.timestamp.Kafka8MessageTimestamp"
+    fi
     run_command "${JAVA} -server -ea -Dlog4j.configuration=log4j.dev.properties \
         -Dconfig=secor.test.backup.properties ${ADDITIONAL_OPTS} -cp $CLASSPATH \
         com.pinterest.secor.main.ConsumerMain > ${LOGS_DIR}/secor_backup.log 2>&1 &"

--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -149,8 +149,8 @@ stop_kafka_server() {
 }
 
 start_secor() {
-    if [ "$MVN_PROFILE" = "kafka-0.8-dev" ];then
-      echo "Detected kafka 0,8 profile, need to run with Kafka8 timestamp class.."
+    if [[ "$MVN_PROFILE" == kafka-0.8* ]];then
+      echo "Detected kafka 0.8 profile, need to run with Kafka8 timestamp class.."
       ADDITIONAL_OPTS="${ADDITIONAL_OPTS} -Dkafka.message.timestamp.className=com.pinterest.secor.timestamp.Kafka8MessageTimestamp"
     fi
     run_command "${JAVA} -server -ea -Dlog4j.configuration=log4j.dev.properties \


### PR DESCRIPTION
Also fixed CI to run with all profiles.

Changes:

You now need to specify a profile when building, because of scala versions clashes and kafka versions etc. 

I didn't get a default profile to work, as toggling it to another profile, the default one was still activated sadly. 