### PR TITLE
Gcs uploadermanager refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-storage</artifactId>
-            <version>1.31.0</version>
+            <version>1.33.0</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -480,6 +480,10 @@ public class SecorConfig {
         return getString("secor.gs.path");
     }
 
+    public double getGsRateLimit() {
+        return getDouble("secor.gs.tasks.ratelimit.pr.second", 10.0);
+    }
+
     public int getGsConnectTimeoutInMs() {
         return getInt("secor.gs.connect.timeout.ms", 3 * 60000);
     }
@@ -582,6 +586,10 @@ public class SecorConfig {
 
     public int getInt(String name, int defaultValue) {
         return mProperties.getInt(name, defaultValue);
+    }
+
+    public double getDouble(String name, double defaultValue) {
+        return mProperties.getDouble(name, defaultValue);
     }
 
     public long getLong(String name) {

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -484,6 +484,11 @@ public class SecorConfig {
         return getDouble("secor.gs.tasks.ratelimit.pr.second", 10.0);
     }
 
+    public int getGsThreadPoolSize() {
+        return getInt("secor.gs.threadpool.fixed.size", 256);
+
+    }
+
     public int getGsConnectTimeoutInMs() {
         return getInt("secor.gs.connect.timeout.ms", 3 * 60000);
     }


### PR DESCRIPTION
Should be reviewed after https://github.com/pinterest/secor/pull/421 as it's rebased on top of this PR.

Also would be nice to get in touch with other GCS users to verify it works for em. This seems to be working for us, but had to add support for throttling towards GCS API usage due to:

> If you get exceptions towards uploading with:

>com.google.cloud.storage.StorageException: Error writing request body to
>server
>
>This is most likley due to you getting throttled / their API respons
>429/5xx. (?) Exception sadly doesn't say anything which is sad library. 
>
>See https://cloud.google.com/storage/docs/request-rate as well.

Throttling it , helped us at least. Most likley due to the time Google need to scale the bucket for more QPS if needed.