### PR TITLE
Honor Message Timestamp Name Separator Env Variable (#425)

### DIFF
--- a/src/main/scripts/docker-entrypoint.sh
+++ b/src/main/scripts/docker-entrypoint.sh
@@ -73,9 +73,9 @@ if [[ ! -z "$MESSAGE_TIMESTAMP_NAME" ]]; then
     SECOR_CONFIG="$SECOR_CONFIG -Dmessage.timestamp.name=$MESSAGE_TIMESTAMP_NAME"
     echo "message.timestamp.name=$MESSAGE_TIMESTAMP_NAME"
 fi
-if [[ ! -z "$MESSAGE_TIMESTAMP_SEPARATOR" ]]; then
-    SECOR_CONFIG="$SECOR_CONFIG -Dmessage.timestamp.separator=$MESSAGE_TIMESTAMP_SEPARATOR"
-    echo "message.timestamp.separator=$MESSAGE_TIMESTAMP_SEPARATOR"
+if [[ ! -z "$MESSAGE_TIMESTAMP_NAME_SEPARATOR" ]]; then
+    SECOR_CONFIG="$SECOR_CONFIG -Dmessage.timestamp.name.separator=$MESSAGE_TIMESTAMP_NAME_SEPARATOR"
+    echo "message.timestamp.name.separator=$MESSAGE_TIMESTAMP_NAME_SEPARATOR"
 fi
 if [[ ! -z "$SECOR_PARSER_TIMEZONE" ]]; then
     SECOR_CONFIG="$SECOR_CONFIG -Dsecor.parser.timezone=$SECOR_PARSER_TIMEZONE"


### PR DESCRIPTION
This PR corrects the env variable that is configuring the timestamp separator in JSON messages. It fixes #425 