### PR TITLE
Updates to helm charts

### DIFF
--- a/deploys/helm/secor/config/log4j.kubernetes-prod.properties
+++ b/deploys/helm/secor/config/log4j.kubernetes-prod.properties
@@ -1,0 +1,12 @@
+# log4j logging configuration.
+
+# root logger.
+log4j.rootLogger=INFO, CONSOLE
+
+log4j.appender.CONSOLE=org.apache.log4j.ConsoleAppender
+log4j.appender.CONSOLE.layout=org.apache.log4j.PatternLayout
+log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} [%t] (%c) %-5p %m%n
+
+# Dont want to be bothered about hadoop saying "Im using compression" every time we upload a file
+log4j.logger.org.apache.hadoop.io.compress.CodecPool = WARN
+log4j.logger.com.pinterest.secor.uploader.GsUploadManager = DEBUG

--- a/deploys/helm/secor/config/secor.kubernetes-prod.properties
+++ b/deploys/helm/secor/config/secor.kubernetes-prod.properties
@@ -115,6 +115,18 @@ swift.api.key=
 # https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload
 secor.gs.upload.direct=false
 
+# Limit the amonut of API calls towards GCS
+# This usually helps against exceptinos of: com.google.cloud.storage.StorageException: Error writing request body to server
+# Cold/Low traffic buckets need to be "warmed" up most likely before you can increase this value.. this is untested.
+# Sadly the client library doesn't say which http response code happens, ie 429 / 5xx etc.
+# Also see https://cloud.google.com/storage/docs/request-rate
+secor.gs.tasks.ratelimit.pr.second=2
+
+# Old behavior of number of threads was 256 , but running this on kubernetes we experience we wanted less threads here,
+# to work well with ratelimit above.
+secor.gs.threadpool.fixed.size=32
+
+
 # Application credentials configuration file
 # https://developers.google.com/identity/protocols/application-default-credentials
 # It can be empty when secor running in Google Cloud VMs with proper scopes
@@ -181,7 +193,7 @@ kafka.dual.commit.enabled=false
 
 # Storage offset.
 # Possible values: "zookeeper" to read offset from zookeeper or "kafka" to read offset from kafka consumer topic
-kafka.offsets.storage=kafka
+kafka.offsets.storage=zookeeper
 
 # Parameter which tells whether to extract Kafka message timestamp. This value is to be chose in case of 0.10.x kafka brokers.
 # Default value is false. Also specify `kafka.message.timestamp.className` as `com.pinterest.secor.timestamp.Kafka10MessageTimestamp`,
@@ -200,10 +212,11 @@ kafka.message.timestamp.className=com.pinterest.secor.timestamp.Kafka10MessageTi
 secor.generation=1
 
 # Number of consumer threads per Secor process.
-secor.consumer.threads=7
+secor.consumer.threads=6
 
 # Consumption rate limit enforced at the process level (not a consumer-thread level).
-secor.messages.per.second=10000
+# Increasing this value can give higher throughput and performance from kafka!
+secor.messages.per.second=400000
 
 # Used by the "backup" consumer group only.
 # Number of continuous message offsets that constitute a single offset= partition on s3.
@@ -435,5 +448,5 @@ secor.swift.path=
 secor.max.file.size.bytes=200000000
 # 1 hour
 # for hourly ingestion/finalization, set this property to smaller value, e.g. 1800
-secor.max.file.age.seconds=900
+secor.max.file.age.seconds=400
 

--- a/deploys/helm/secor/config/secor.kubernetes-test.properties
+++ b/deploys/helm/secor/config/secor.kubernetes-test.properties
@@ -116,6 +116,17 @@ swift.api.key=
 # see https://github.com/pinterest/secor/issues/177
 # https://cloud.google.com/storage/docs/json_api/v1/how-tos/upload
 secor.gs.upload.direct=false
+        
+# Limit the amonut of API calls towards GCS
+# This usually helps against exceptinos of: com.google.cloud.storage.StorageException: Error writing request body to server
+# Cold/Low traffic buckets need to be "warmed" up most likely before you can increase this value.. this is untested.
+# Sadly the client library doesn't say which http response code happens, ie 429 / 5xx etc.
+# Also see https://cloud.google.com/storage/docs/request-rate
+secor.gs.tasks.ratelimit.pr.second=2
+
+# Old behavior of number of threads was 256 , but running this on kubernetes we experience we wanted less threads here,
+# to work well with ratelimit above.
+secor.gs.threadpool.fixed.size=32
 
 # Application credentials configuration file
 # https://developers.google.com/identity/protocols/application-default-credentials

--- a/deploys/helm/secor/templates/secor-backup-statefulset.yaml
+++ b/deploys/helm/secor/templates/secor-backup-statefulset.yaml
@@ -42,6 +42,8 @@ spec:
               value: "{{ .Values.secor.zookeeper.quorum }}"
             - name: "ZOOKEEPER_PATH"
               value: "/"
+            - name: "JVM_MEMORY"
+              value: "{{ .Values.secor.backup.jvm.memory }}"
 
           volumeMounts:
             - mountPath: "/opt/secor/config"
@@ -50,7 +52,8 @@ spec:
               mountPath: "/var/run/secret/cloud.google.com"
             - name: "local-var"
               mountPath: "/mnt/secor_data/message_logs/backup"
-
+          resources:
+{{ toYaml .Values.secor.backup.resources | indent 12 }}
 
         - name: monitor
           image: {{ .Values.image.prefix }}{{ .Values.image.repository }}:{{ .Values.image.tag }}

--- a/deploys/helm/secor/templates/secor-statefulset.yaml
+++ b/deploys/helm/secor/templates/secor-statefulset.yaml
@@ -31,13 +31,15 @@ spec:
             - name: "CONFIG_FILE"
               value: "{{ .Values.secor.partition.configFile }}"
             - name: "LOG4J_CONFIGURATION"
-              value: "config/log4j.docker.properties"
+              value: "{{ .Values.secor.partition.logConfigFile }}"
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
               value: "/var/run/secret/cloud.google.com/service-account.json"
             - name: "ZOOKEEPER_QUORUM"
               value: "{{ .Values.secor.zookeeper.quorum }}"
             - name: "ZOOKEEPER_PATH"
               value: "{{ .Values.secor.zookeeper.path }}"
+            - name: "JVM_MEMORY"
+              value: "{{ .Values.secor.partition.jvm.memory }}"
 
           volumeMounts:
            - mountPath: /opt/secor/config
@@ -46,7 +48,8 @@ spec:
              mountPath: "/var/run/secret/cloud.google.com"
            - name: "local-var"
              mountPath: "/mnt/secor_data/message_logs/partition"
-
+          resources:
+{{ toYaml .Values.secor.partition.resources | indent 12 }}
 
         - name: monitor
           image: {{ .Values.image.prefix }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -55,7 +58,7 @@ spec:
             - name: "CONFIG_FILE"
               value: "{{ .Values.secor.partition.configFile }}"
             - name: "LOG4J_CONFIGURATION"
-              value: "config/log4j.docker.properties"
+              value: "{{ .Values.secor.partition.monitor.logConfigFile }}"
             - name: "SECOR_MAIN_CLASS"
               value: "com.pinterest.secor.main.ProgressMonitorMain"
             - name: "GOOGLE_APPLICATION_CREDENTIALS"
@@ -94,12 +97,12 @@ spec:
     - metadata:
         name: local-var
         labels:
-          app: secor
+          app: {{ template "secor.fullname" . }}
         annotations:
-          volume.beta.kubernetes.io/storage-class: standard
+          volume.beta.kubernetes.io/storage-class: "{{ .Values.secor.partition.storage.class }}"
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 20Gi
+            storage: "{{ .Values.secor.partition.storage.size }}"

--- a/deploys/helm/secor/values.yaml
+++ b/deploys/helm/secor/values.yaml
@@ -1,5 +1,5 @@
 image:
-  prefix: us.gcr.io/demo/
+  prefix: us.gcr.io/secor-demo/
   repository: secor
   tag: latest
   pullPolicy: Always
@@ -16,10 +16,27 @@ secor:
     storage:
       class: standard
       size: 20Gi
+    jvm:
+      memory: 512m
+    resources:
+      requests:
+        cpu: 800m
+        memory: 768Mi
   partition:
     configFile: /opt/secor/config/secor.kubernetes-dev.partition.properties
     logConfigFile: /opt/secor/config/log4j.docker.properties
-
+    monitor:
+      logConfigFile: /opt/secor/config/log4j.docker-warn.properties
+    storage:
+      class: standard
+      size: 20Gi
+    jvm:
+      memory: 512m
+    resources:
+      requests:
+        cpu: 800m
+        memory: 768Mi
+ 
 
 exporter:
   image:

--- a/deploys/helm/values-secor.yaml
+++ b/deploys/helm/values-secor.yaml
@@ -1,7 +1,31 @@
+# Example of production values
 secor:
   zookeeper:
-    quorum: "kafka-zookeeper.default:2181"
+    quorum: "kafka-zookeeper:2181"
   backup:
-    configFile: /opt/secor/config/secor.kubernetes-test.backup.properties
+    configFile: /opt/secor/config/secor.kubernetes-prod.backup.properties
+    logConfigFile: /opt/secor/config/log4j.kubernetes-prod.properties
+    storage:
+      class: standard
+      size: 100Gi
+    jvm:
+      memory: 6144m
+    resources:
+      requests:
+        #cpu: 8000m # If backfilling!
+        cpu: 1000m
+        memory: 5000Mi
+ 
   partition:
-    configFile: /opt/secor/config/secor.kubernetes-test.partition.properties
+    configFile: /opt/secor/config/secor.kubernetes-prod.partition.properties
+    logConfigFile: /opt/secor/config/log4j.kubernetes-prod.properties
+    storage:
+      class: standard
+      size: 100Gi
+    jvm:
+      memory: 6144m
+    resources:
+      requests:
+        #cpu: 8000m # If backfilling!
+        cpu: 1000m
+        memory: 5000Mi


### PR DESCRIPTION
New log4j.kubernetes-prod.properties config:
Don't want to have "Im using this compression" for every upload.

Added the refactored GCS upload manager configs for avoid flooding GCS
API.

Max age to 400 seconds, what we currently use in production and these
config values works with on kubernetes for us.

Offsets in zookeeper instead of kafka, due to other main programs which
reads offsets from kafka for keeping track.

In helm charts:

Support for adding resources, ie requests and limits from values in
helm.

Specific log4j config files.

JVM memory

and yes, requests lower then jvm volume looks weird, but we allow to
overcommit on some memory usage to utilize nodes better in kubernetes.
Still under review and testing. Currently still observed lower memory
then what is requested..

Important config value to know about: secor.messages.per.second
Increasing this gave us way higher oommmffff consuming from kafka :-)