### PR TITLE
Use secure Maven repositories

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,32 +88,32 @@
     <repositories>
         <repository>
             <id>Twitter public Maven repo</id>
-            <url>http://maven.twttr.com</url>
+            <url>https://maven.twttr.com</url>
         </repository>
         <repository>
             <id>Typesafe public Maven repo</id>
-            <url>http://repo.typesafe.com/typesafe/releases</url>
+            <url>https://repo.typesafe.com/typesafe/releases</url>
         </repository>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
         <repository>
             <id>central</id>
             <name>Maven Repository Switchboard</name>
             <layout>default</layout>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>Twitter public Maven repo</id>
-            <url>http://maven.twttr.com</url>
+            <url>https://maven.twttr.com</url>
         </pluginRepository>
         <pluginRepository>
             <id>Typesafe public Maven repo</id>
-            <url>http://repo.typesafe.com/typesafe/releases</url>
+            <url>https://repo.typesafe.com/typesafe/releases</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
When importing Secor artifact using Leingen the following fatal error is thrown: **Tried to use insecure HTTP repository without TLS.** This is because some repositories are defined to use HTTP instead of HTTPS. 
This patch replaces all insecure repositories with their HTTPS version.