### PR TITLE
Avoid resolving ZK hosts too early

### DIFF
--- a/src/main/java/com/pinterest/secor/common/ZookeeperConnector.java
+++ b/src/main/java/com/pinterest/secor/common/ZookeeperConnector.java
@@ -67,7 +67,7 @@ public class ZookeeperConnector {
             assert elements.length == 2: Integer.toString(elements.length) + " == 2";
             String host = elements[0];
             int port = Integer.parseInt(elements[1]);
-            result.add(new InetSocketAddress(host, port));
+            result.add(InetSocketAddress.createUnresolved(host, port));
         }
         return result;
     }


### PR DESCRIPTION
What happens is during the construction of ZK client provided addresses are resolved due to default behaviour of InetSocketAddress. Now, if a ZK server changes its IP address Secor stops working until restarted. Here are the error that we get:

```
[Thread-15-SendThread(ip-10-118-20-99.eu-west-1.compute.internal:2181)] WARN org.apache.zookeeper.ClientCnxn - Session 0x100a9194f500006 for server null, unexpected error, closing socket connection and attempting reconnect
java.net.NoRouteToHostException: Host is unreachable
at sun.nio.ch.SocketChannelImpl.checkConnect(Native Method)
at sun.nio.ch.SocketChannelImpl.finishConnect(SocketChannelImpl.java:717)
at org.apache.zookeeper.ClientCnxnSocketNIO.doTransport(ClientCnxnSocketNIO.java:361)
at org.apache.zookeeper.ClientCnxn$SendThread.run(ClientCnxn.java:1081)
```
