### PR TITLE
POC: Commit offsets also to kafka while keeping offsets.storage=zookeeper

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -231,6 +231,12 @@ kafka.zookeeper.path=/
 #Only acquired used for decoding Avro messages
 schema.registry.url=
 
+# Commit offsets additionally to kafka offsets storage (for reference).
+# This is just to allow tracking offsets also via Kafka offset storage. Secor still uses Zookeeper as the offset storage
+# internally.
+# Possible values: true or false - true is not allowed if kafka.offsets.storage=kafka
+secor.offsets.commitToKafkaOffsetStorageForReference=false
+
 # Store offset in zookeeper and kafka consumer topic.
 # Only used if kafka.offsets.storage is set to "kafka"
 # http://kafka.apache.org/documentation.html#oldconsumerconfigs

--- a/src/main/java/com/pinterest/secor/common/SecorConstants.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConstants.java
@@ -3,4 +3,6 @@ package com.pinterest.secor.common;
 public class SecorConstants {
     public static final String KAFKA_OFFSETS_STORAGE_ZK = "zookeeper";
     public static final String KAFKA_OFFSETS_STORAGE_KAFKA = "kafka";
+    public static final String COMMIT_TO_KAFKA_OFFSET_STORAGE_FOR_REFERENCE =
+            "secor.offsets.commitToKafkaOffsetStorageForReference";
 }

--- a/src/main/java/com/pinterest/secor/reader/KafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/KafkaMessageIterator.java
@@ -11,4 +11,5 @@ public interface KafkaMessageIterator {
     Message next();
     void init(SecorConfig config) throws UnknownHostException;
     void commit(TopicPartition topicPartition, long offset);
+    void commitToKafka(TopicPartition topicPartition, long offset);
 }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -117,4 +117,8 @@ public class MessageReader {
     public void commit(TopicPartition topicPartition, long offset) {
         mKafkaMessageIterator.commit(topicPartition, offset);
     }
+
+    public void commitToKafka(TopicPartition topicPartition, long offset) {
+        mKafkaMessageIterator.commitToKafka(topicPartition, offset);
+    }
 }

--- a/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
@@ -3,6 +3,7 @@ package com.pinterest.secor.reader;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.SecorConstants;
 import com.pinterest.secor.common.ZookeeperConnector;
 import com.pinterest.secor.message.Message;
 import com.pinterest.secor.util.IdUtil;
@@ -158,6 +159,13 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator {
         } catch (CommitFailedException e) {
             LOG.trace("kafka commit failed due to group re-balance", e);
         }
+    }
+
+    @Override
+    public void commitToKafka(com.pinterest.secor.common.TopicPartition topicPartition, long offset) {
+        // TODO this can be implemented in the same way as in LegacyKafkaMessageIterator if needed
+        throw new UnsupportedOperationException(SecorConstants.COMMIT_TO_KAFKA_OFFSET_STORAGE_FOR_REFERENCE +
+                " is not implemented for " + this.getClass());
     }
 
     private void optionalConfig(String maybeConf, Consumer<String> configConsumer) {


### PR DESCRIPTION
Secor is still heavily dependent on using Zookeeper as an offset storage:
- There doesn't seem to be a configuration combination for kafka version profiles < 2.0.0 that would allow committing offsets to kafka without loss of data.
   - If `kafka.offsets.storage=kafka`, offsets of all partitions are committed at once (see `LegacyKafkaMessageIterator#commit`), which can cause data loss
- Even with the 2.0.0 profile offsets are committed to kafka only if `kafka.offsets.storage=kafka`

----

My use case is that there are many kafka offset monitoring tools that only support the kafka offset storage, not zookeeper. And we're not likely to upgrade to kafka 2.0.0 very soon.

To support that secor would have to either:
**A**) support committing offsets additionally to kafka offset storage
**B**) support committing offsets correctly in `LegacyKafkaMessageIterator#commit`

This PR is an _incremental_ POC of **A** – adding this doesn't change any of the existing behavior, so at least this is totally safe.

However, it would be better if **B** can be done. Is there any reason why `LegacyKafkaMessageIterator#commit` couldn't be changed to do what `#commitToKafka` in this PR does? If not, then it would be enough to implement **B**.

**TODO:** (for **B**) I'm not sure if the `ConsumerConnector#commitOffsets` (that `LegacyKafkaMessageIterator` uses) is synchronous or not – but would it even have to be? I'm wondering because `SecorKafkaMessageIterator` calls `KafkaConsumer#commitSync`.

----

For background: https://github.com/pinterest/secor/pull/450#issuecomment-436914329 and also the PR https://github.com/pinterest/secor/pull/450 as a whole.

----

Travis build currently fails for `MVN_PROFILE=kafka-0.8.2.1`. This will be fixed if this PR gets some yellow light.

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project secor: Compilation failure: Compilation failure: 
[ERROR] /home/travis/build/pinterest/secor/src/main/java/com/pinterest/secor/reader/LegacyKafkaMessageIterator.java:[10,19] error: cannot find symbol
[ERROR] 
[ERROR] could not parse error message:   symbol:   class OffsetMetadata
[ERROR]   location: package kafka.common
[ERROR] /home/travis/build/pinterest/secor/src/main/java/com/pinterest/secor/reader/LegacyKafkaMessageIterator.java:15: error: cannot find symbol
[ERROR] import org.apache.kafka.clients.consumer.CommitFailedException;
[ERROR]                                         ^
[ERROR] 
[ERROR] could not parse error message:   symbol:   class CommitFailedException
[ERROR]   location: package org.apache.kafka.clients.consumer
[ERROR] /home/travis/build/pinterest/secor/src/main/java/com/pinterest/secor/reader/LegacyKafkaMessageIterator.java:94: error: cannot find symbol
[ERROR]         OffsetAndMetadata offsetAndMetadata = new OffsetAndMetadata(new OffsetMetadata(offset, null),
[ERROR]                                                                         ^
[ERROR] 
[ERROR] could not parse error message:   symbol:   class OffsetMetadata
[ERROR]   location: class LegacyKafkaMessageIterator
[ERROR] /home/travis/build/pinterest/secor/src/main/java/com/pinterest/secor/reader/LegacyKafkaMessageIterator.java:100: error: no suitable method found for commitOffsets(Map<TopicAndPartition,OffsetAndMetadata>,boolean)
[ERROR]             mKafkaCommitter.commitOffsets(offsets, true);
[ERROR]                            ^
[ERROR] 
[ERROR]     method ConsumerConnector.commitOffsets() is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR]     method ConsumerConnector.commitOffsets(boolean) is not applicable
[ERROR]       (actual and formal argument lists differ in length)
[ERROR] /home/travis/build/pinterest/secor/src/main/java/com/pinterest/secor/reader/LegacyKafkaMessageIterator.java:[101,17] error: cannot find symbol
```
