### PR TITLE
Join the two executions of the maven-exec-plugin to avoid a Maven warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,7 @@
                 <version>1.1</version>
                 <executions>
                     <execution>
+                        <id>create-build-properties</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>exec</goal>
@@ -382,6 +383,22 @@
                                 <argument>-n1</argument>
                             </arguments>
                             <outputFile>target/build.properties</outputFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>create-classes-build-properties</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>git</executable>
+                            <arguments>
+                                <argument>log</argument>
+                                <argument>--pretty=format:build_revision=%H</argument>
+                                <argument>-n1</argument>
+                            </arguments>
+                            <outputFile>target/classes/com/pinterest/secor/common/build.properties</outputFile>
                         </configuration>
                     </execution>
                 </executions>
@@ -397,28 +414,6 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>1.1</version>
-                <executions>
-                    <execution>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>git</executable>
-                            <arguments>
-                                <argument>log</argument>
-                                <argument>--pretty=format:build_revision=%H</argument>
-                                <argument>-n1</argument>
-                            </arguments>
-                            <outputFile>target/classes/com/pinterest/secor/common/build.properties</outputFile>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Similar to #220, but instead of removing the second execution I opted for just fixing the warning. I cannot yet see whether one of the two executions is actually removable right now.

~~~~
$ mvn -Pkafka-2.0.0 package
Picked up _JAVA_OPTIONS: -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true -Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel -Dsun.java2d.xrender=true
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.pinterest:secor:jar:0.27-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:exec-maven-plugin @ line 404, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] Inspecting build with total of 1 modules...
...
~~~~