### PR TITLE
Disable the use of the system classloader for surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -607,6 +607,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
This works around https://issues.apache.org/jira/browse/SUREFIRE-1588.

---
This fixes building on recent Debians (particularly inside the docker `openjdk:8-jdk` image) for me. 