### PR TITLE
Don't depend on nested repackaged Guava

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -16,7 +16,7 @@
  */
 package com.pinterest.secor.common;
 
-import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Strings;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.ConfigurationUtils;
 import org.apache.commons.configuration.PropertiesConfiguration;


### PR DESCRIPTION
We have a perfectly fine copy of com.google.common.base.Strings that doesn't
depend on implementation details of the Google API client.