### PR TITLE
ProgressMonitor: support Datadog-style tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,9 +334,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>com.timgroup</groupId>
-            <artifactId>java-statsd-client</artifactId>
-            <version>3.0.2</version>
+            <groupId>com.datadoghq</groupId>
+            <artifactId>java-dogstatsd-client</artifactId>
+            <version>2.6.1</version>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -341,7 +341,8 @@ secor.thrift.protocol.class=
 secor.thrift.message.class.*=
 
 # If true, the consumer group will be the initial prefix of all
-# exported metrics, before `monitoring.prefix` (if set).
+# exported metrics, before `monitoring.prefix` (if set). (Ignored
+# if statsd.datadog.tags.enabled is set.)
 #
 # Setting to false and use monitoring.prefix can lead to nice paths.
 # For example,
@@ -355,6 +356,15 @@ secor.thrift.message.class.*=
 #   statsd.prefixWithConsumerGroup = true
 #   => secor_hr_partition.secor.lag.offsets.<topic>.<partition>
 statsd.prefixWithConsumerGroup=true
+
+# If true, put the topic, partition, and group in dogstatsd tags rather than in
+# the metrics name. dogstatsd is an extension to statsd used by Datadog.
+statsd.dogstatsd.tags.enabled=false
+
+# This comma-separated list of tags will be included with all statsd gauges,
+# using the dogstatd format used by Datadog. (This will be applied even if
+# statsd.dogstatsd.tags.enabled is false.)
+statsd.dogstatsd.constant.tags=
 
 # Name of field that contains timestamp for JSON, MessagePack, or Thrift message parser. (1405970352123)
 message.timestamp.name=timestamp

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -487,6 +487,14 @@ public class SecorConfig {
     	return getBoolean("statsd.prefixWithConsumerGroup");
     }
 
+    public boolean getStatsdDogstatdsTagsEnabled() {
+        return getBoolean("statsd.dogstatsd.tags.enabled");
+    }
+
+    public String[] getStatsDDogstatsdConstantTags() {
+        return getStringArray("statsd.dogstatsd.constant.tags");
+    }
+
     public String getMonitoringBlacklistTopics() {
         return getString("monitoring.blacklist.topics");
     }


### PR DESCRIPTION
Datadog's java-dogstatsd-client is a backwards-compatible extension to
java-statsd-client which works with normal statsd servers as well as Datadog's
dogstatsd server. This change is backwards compatible.