### PR TITLE
Avoid putting Message key/payload in an exception

### DIFF
--- a/src/main/java/com/pinterest/secor/consumer/Consumer.java
+++ b/src/main/java/com/pinterest/secor/consumer/Consumer.java
@@ -167,7 +167,13 @@ public class Consumer extends Thread {
                     mMetricCollector.metric("consumer.message_size_bytes", rawMessage.getPayload().length, rawMessage.getTopic());
                     mMetricCollector.increment("consumer.throughput_bytes", rawMessage.getPayload().length, rawMessage.getTopic());
                 } catch (Exception e) {
-                    throw new RuntimeException("Failed to write message " + parsedMessage, e);
+                    // Log the full stringification of parsedMessage at DEBUG level, but include only a truncated
+                    // version in the thrown exception, since messages can be ginormous and this exception often
+                    // just indicates an IO error unrelated to the message content.
+                    if (LOG.isTraceEnabled()) {
+                        LOG.trace("Failed to write message " + parsedMessage, e);
+                    }
+                    throw new RuntimeException("Failed to write message " + parsedMessage.toTruncatedString(), e);
                 }
             }
         }

--- a/src/main/java/com/pinterest/secor/message/ParsedMessage.java
+++ b/src/main/java/com/pinterest/secor/message/ParsedMessage.java
@@ -30,8 +30,13 @@ public class ParsedMessage extends Message {
 
     @Override
     public String toString() {
-        return "ParsedMessage{" + fieldsToString() +  ", mPartitions=" +
+        return "ParsedMessage{" + fieldsToString(false) +  ", mPartitions=" +
                Arrays.toString(mPartitions) + '}';
+    }
+
+    public String toTruncatedString() {
+        return "ParsedMessage{" + fieldsToString(true) +  ", mPartitions=" +
+                Arrays.toString(mPartitions) + '}';
     }
 
     public ParsedMessage(String topic, int kafkaPartition, long offset, byte[] kafkaKey, byte[] payload,

--- a/src/test/java/com/pinterest/secor/message/MessageTest.java
+++ b/src/test/java/com/pinterest/secor/message/MessageTest.java
@@ -13,4 +13,13 @@ public class MessageTest {
 	// NullPointerException
     }
 
+    @Test
+    public void testBinaryKeyAndPayloadToString() {
+        Message message = new Message("testTopic", 0, 123,
+                new byte[]{(byte)0x80}, new byte[]{(byte)0x80}, 0l);
+        // no assert necessary, just making sure it does not throw a
+        // NullPointerException
+        System.out.println(message);
+    }
+
 }


### PR DESCRIPTION
This exception happens frequently due to IO errors or due to FileRegistry
throwing during shutdown, so including what might be a ginormous binary blob
isn't great.

While we're at it, ensure that Message.toString() doesn't throw on non-UTF-8
data by explicitly using CharsetDecoder rather than relying on explicitly
unspecified behavior of `new String(byte[])`.

Fixes #474.