### PR TITLE
Upload during graceful shutdown

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -446,6 +446,11 @@ secor.kafka.upload_at_minute_mark.topic_filter=
 # What the minute mark is. This isn't triggered unless the topic name matches
 secor.upload.minute_mark=0
 
+# If true, runs a final upload when the JVM is shut down (eg, from SIGTERM).
+# You may want to ensure that whatever system you use to run secor sets an
+# appropriate grace period to allow a full upload before a forced termination.
+secor.upload.on.shutdown=false
+
 # File age per topic and per partition is checked against secor.max.file.age.seconds by looking at
 # the youngest file when true or at the oldest file when false. Setting it to true ensures that files
 # are uploaded when data stops comming and sized based policy cannot trigger. Setting it to false

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -271,6 +271,10 @@ public class SecorConfig {
         return getLong("secor.max.file.age.seconds");
     }
 
+    public boolean getUploadOnShutdown() {
+        return getBoolean("secor.upload.on.shutdown");
+    }
+
     public boolean getFileAgeYoungest() {
         return getBoolean("secor.file.age.youngest");
     }

--- a/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
+++ b/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
@@ -140,7 +140,7 @@ public class UploaderTest extends TestCase {
         PowerMockito.mockStatic(FileUtil.class);
         Mockito.when(FileUtil.getPrefix("some_topic", mConfig)).
                 thenReturn("s3a://some_bucket/some_s3_parent_dir");
-        mUploader.applyPolicy();
+        mUploader.applyPolicy(false);
 
         final String lockPath = "/secor/locks/some_topic/0";
         Mockito.verify(mZookeeperConnector).lock(lockPath);
@@ -188,7 +188,7 @@ public class UploaderTest extends TestCase {
         PowerMockito.mockStatic(FileUtil.class);
         Mockito.when(FileUtil.getPrefix("some_topic", mConfig)).
                 thenReturn("s3a://some_bucket/some_s3_parent_dir");
-        mUploader.applyPolicy();
+        mUploader.applyPolicy(false);
 
         final String lockPath = "/secor/locks/some_topic/0";
         Mockito.verify(mZookeeperConnector).lock(lockPath);
@@ -216,7 +216,7 @@ public class UploaderTest extends TestCase {
         Mockito.when(mOffsetTracker.getLastSeenOffset(mTopicPartition))
                 .thenReturn(20L);
 
-        mUploader.applyPolicy();
+        mUploader.applyPolicy(false);
 
         Mockito.verify(mFileRegistry).deleteTopicPartition(mTopicPartition);
     }
@@ -225,9 +225,10 @@ public class UploaderTest extends TestCase {
         Mockito.when(
                 mZookeeperConnector.getCommittedOffsetCount(mTopicPartition))
                 .thenReturn(21L);
+        // The second time it's called, it returns 21L because of the first call.
         Mockito.when(
                 mOffsetTracker.setCommittedOffsetCount(mTopicPartition, 21L))
-                .thenReturn(20L);
+                .thenReturn(20L, 21L);
         Mockito.when(mOffsetTracker.getLastSeenOffset(mTopicPartition))
                 .thenReturn(21L);
 
@@ -263,7 +264,7 @@ public class UploaderTest extends TestCase {
         Mockito.when(mFileRegistry.getOrCreateWriter(dstLogFilePath, null))
                 .thenReturn(writer);
 
-        mUploader.applyPolicy();
+        mUploader.applyPolicy(false);
 
         Mockito.verify(writer).write(Mockito.any(KeyValue.class));
         Mockito.verify(mFileRegistry).deletePath(mLogFilePath);


### PR DESCRIPTION
This new feature is disabled by default. However, there are two
other small changes introduced even with secor.upload.on.shutdown=false:

- If KafkaMessageIterator returns false from hasNext (only possible with the
  legacy iterator), perform a final upload at the end in this case too (whether
  or not the graceful shutdown feature is enabled).

- After trimming files, we immediate check again to see if we're supposed to
  upload the TopicPartition. This is needed for graceful shutdown (since there's
  not going to be another call to checkTopicPartition) and may also be helpful
  in other configurations.