### PR TITLE
Fix deadlock when secor.upload.on.shutdown=true

### DIFF
--- a/src/main/java/com/pinterest/secor/main/ConsumerMain.java
+++ b/src/main/java/com/pinterest/secor/main/ConsumerMain.java
@@ -62,17 +62,10 @@ public class ConsumerMain {
             logFileDeleter.deleteOldLogs();
 
             RateLimitUtil.configure(config);
-            Thread.UncaughtExceptionHandler handler = new Thread.UncaughtExceptionHandler() {
-                public void uncaughtException(Thread thread, Throwable exception) {
-                    LOG.error("Thread {} failed", thread, exception);
-                    System.exit(1);
-                }
-            };
             LOG.info("starting {} consumer threads", config.getConsumerThreads());
             LinkedList<Consumer> consumers = new LinkedList<Consumer>();
             for (int i = 0; i < config.getConsumerThreads(); ++i) {
                 Consumer consumer = new Consumer(config);
-                consumer.setUncaughtExceptionHandler(handler);
                 consumers.add(consumer);
                 consumer.start();
             }


### PR DESCRIPTION
The secor.upload.on.shutdown feature worked fine if we were shutting down
because we received a signal, but not if we were shutting down because a
Consumer thread had crashed and the UncaughtExceptionHandler had called
System.exit(1). In that case we'd get a deadlock and the program would never
exit.

Change the shutdown hook to do nothing if any Consumer thread called
System.exit.

The simplest way to implement this is to move the UncaughtExceptionHandler into
the Consumer thread itself as a big try block, so I did that.