### PR TITLE
add message.timestamp.skew.max.ms to secor configuration

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -537,6 +537,8 @@ public class SecorConfig {
         return mProperties.getBoolean("message.timestamp.required");
     }
 
+    public long getMessageTimestampSkewMaxMs() { return getLong("message.timestamp.skew.max.ms"); }
+
     public String getMessageSplitFieldName() {
         return getString("message.split.field.name");
     }


### PR DESCRIPTION
Some message parser may want to skip messages that have severe message timestamp skew. This change is to add a configuration setting to allow the parsers to do this.  