### PR TITLE
Add deterministic upload mode

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -451,6 +451,27 @@ secor.upload.minute_mark=0
 # appropriate grace period to allow a full upload before a forced termination.
 secor.upload.on.shutdown=false
 
+# If true, uploads are entirely deterministic, which can avoid some race conditions
+# which can lead to messages being backed up multiple times. This is incompatible with
+# secor.upload.on.shutdown=true, and ignores the values of secor.max.file.size.bytes,
+# secor.max.file.age.seconds, and secor.upload.minute_mark.
+#
+# In deterministic mode, you must set one or both of secor.max.file.timestamp.range.millis and
+# secor.max.input.payload.size.bytes. These determine when to upload, and are ignored outside
+# of deterministic mode.
+secor.upload.deterministic=false
+
+# If this is set, upload files when the range between earliest and latest
+# timestamp in messages read reaches this value. You must set kafka.useTimestamp
+# to true and you must use a secor.file.reader.writer.factory which supports
+# timestamps. This is ignored outside of deterministic mode.
+secor.max.file.timestamp.range.millis=0
+
+# If this is set, upload files when the total size of *input* payloads (not
+# output log files) reaches this value. This is ignored outside of deterministic
+# mode.
+secor.max.input.payload.size.bytes=0
+
 # File age per topic and per partition is checked against secor.max.file.age.seconds by looking at
 # the youngest file when true or at the oldest file when false. Setting it to true ensures that files
 # are uploaded when data stops comming and sized based policy cannot trigger. Setting it to false

--- a/src/main/java/com/pinterest/secor/common/DeterministicUploadPolicyTracker.java
+++ b/src/main/java/com/pinterest/secor/common/DeterministicUploadPolicyTracker.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.pinterest.secor.common;
+
+import com.pinterest.secor.io.KeyValue;
+import com.pinterest.secor.message.Message;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * DeterministicUploadPolicyTracker stores the range of timestamps seen so far for a given TopicPartition.
+ * It lets us implement a "time-based" upload policy that is still deterministic.
+ */
+public class DeterministicUploadPolicyTracker
+{
+  private final long mMaxFileTimestampRangeMillis;
+  private final long mMaxInputPayloadSizeBytes;
+
+  private static class TopicPartitionStats {
+    long earliestTimestamp;
+    long latestTimestamp;
+    long totalInputPayloadSizeBytes;
+    TopicPartitionStats(long earliestTimestamp, long latestTimestamp, long totalInputPayloadSizeBytes) {
+      this.earliestTimestamp = earliestTimestamp;
+      this.latestTimestamp = latestTimestamp;
+      this.totalInputPayloadSizeBytes = totalInputPayloadSizeBytes;
+    }
+  }
+
+  private Map<TopicPartition, TopicPartitionStats> mStats;
+
+  public DeterministicUploadPolicyTracker(long maxFileTimestampRangeMillis, long maxInputPayloadSizeBytes)
+  {
+    if (maxFileTimestampRangeMillis > 0) {
+      mMaxFileTimestampRangeMillis = maxFileTimestampRangeMillis;
+    } else {
+      mMaxFileTimestampRangeMillis = Long.MAX_VALUE;
+    }
+    if (maxInputPayloadSizeBytes > 0) {
+      mMaxInputPayloadSizeBytes = maxInputPayloadSizeBytes;
+    } else {
+      mMaxInputPayloadSizeBytes = Long.MAX_VALUE;
+    }
+    if (mMaxFileTimestampRangeMillis == Long.MAX_VALUE && mMaxInputPayloadSizeBytes == Long.MAX_VALUE) {
+      throw new RuntimeException("When secor.upload.deterministic is true, you must set either " +
+                                 "secor.max.file.timestamp.range.millis or secor.max.input.payload.size.bytes");
+    }
+    mStats = new HashMap<>();
+  }
+
+  public void track(Message message) {
+    track(new TopicPartition(message.getTopic(), message.getKafkaPartition()),
+          message.getTimestamp(),
+          message.getPayload().length);
+  }
+
+  public void track(TopicPartition topicPartition, KeyValue kv) {
+    track(topicPartition, kv.getTimestamp(), kv.getValue().length);
+  }
+
+  private void track(TopicPartition topicPartition, long timestamp, long inputPayloadSizeBytes) {
+    if (timestamp <= 0 && mMaxFileTimestampRangeMillis != Long.MAX_VALUE) {
+      throw new RuntimeException("Message without timestamp incompatible with secor.max.file.timestamp.range.millis");
+    }
+    final TopicPartitionStats stats = mStats.get(topicPartition);
+    if (stats == null) {
+      mStats.put(topicPartition, new TopicPartitionStats(timestamp, timestamp, inputPayloadSizeBytes));
+    } else {
+      stats.earliestTimestamp = Math.min(stats.earliestTimestamp, timestamp);
+      stats.latestTimestamp = Math.max(stats.latestTimestamp, timestamp);
+      stats.totalInputPayloadSizeBytes += inputPayloadSizeBytes;
+    }
+
+  }
+
+  public void reset(TopicPartition topicPartition)
+  {
+    mStats.remove(topicPartition);
+  }
+
+  public boolean shouldUpload(TopicPartition topicPartition) {
+    final TopicPartitionStats stats = mStats.get(topicPartition);
+    if (stats == null) {
+      // No messages at all: definitely not ready for upload.
+      return false;
+    }
+    return stats.totalInputPayloadSizeBytes >= mMaxInputPayloadSizeBytes
+        || (stats.latestTimestamp - stats.earliestTimestamp) >= mMaxFileTimestampRangeMillis;
+  }
+}

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -277,6 +277,18 @@ public class SecorConfig {
         return getBoolean("secor.upload.on.shutdown");
     }
 
+    public boolean getDeterministicUpload() {
+        return getBoolean("secor.upload.deterministic");
+    }
+
+    public long getMaxFileTimestampRangeMillis() {
+        return getLong("secor.max.file.timestamp.range.millis");
+    }
+
+    public long getMaxInputPayloadSizeBytes() {
+        return getLong("secor.max.input.payload.size.bytes");
+    }
+
     public boolean getFileAgeYoungest() {
         return getBoolean("secor.file.age.youngest");
     }

--- a/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
+++ b/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
@@ -62,7 +62,8 @@ public class UploaderTest extends TestCase {
                             UploadManager uploadManager,
                             MessageReader messageReader,
                             ZookeeperConnector zookeeperConnector) {
-            init(config, offsetTracker, fileRegistry, uploadManager, messageReader, zookeeperConnector, Mockito.mock(MetricCollector.class));
+            init(config, offsetTracker, fileRegistry, uploadManager, messageReader, zookeeperConnector,
+                 Mockito.mock(MetricCollector.class), null);
             mReader = Mockito.mock(FileReader.class);
         }
 


### PR DESCRIPTION
This is to avoid #600.

In this mode, decisions about whether to upload files are *only* based on
properties of the input messages themselves: timestamps and input message
payload size.  We don't care about real-world time, disk file timestamps, or log
file size; we don't support upload on shutdown; and we check for uploads after
every message.

Configuration:

- set secor.upload.deterministic=true
- Configure at least one of secor.max.file.timestamp.range.millis and
  secor.max.input.payload.size.bytes.
- If you've configured secor.max.file.timestamp.range.millis, you must
  set kafka.useTimestamp=true and ensure that your FileReader/FileWriter
  supports timestamps.