### PR TITLE
Send null messages to kafka avro deserializer

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorSchemaRegistryClient.java
+++ b/src/main/java/com/pinterest/secor/common/SecorSchemaRegistryClient.java
@@ -56,9 +56,14 @@ public class SecorSchemaRegistryClient {
     }
 
     public GenericRecord decodeMessage(String topic, byte[] message) {
+        if (message.length == 0) {
+            message = null;
+        }
         GenericRecord record = (GenericRecord) deserializer.deserialize(topic, message);
-        Schema schema = record.getSchema();
-        schemas.put(topic, schema);
+        if (record != null) {
+            Schema schema = record.getSchema();
+            schemas.put(topic, schema);
+        }
         return record;
     }
 

--- a/src/test/java/com/pinterest/secor/common/SecorSchemaRegistryClientTest.java
+++ b/src/test/java/com/pinterest/secor/common/SecorSchemaRegistryClientTest.java
@@ -99,5 +99,8 @@ public class SecorSchemaRegistryClientTest extends TestCase {
         assertEquals(output.get("data_field_1"), 1);
         assertTrue(StringUtils.equals((output.get("data_field_2")).toString(), "hello"));
         assertEquals(output.get("timestamp"), 1467176316L);
+
+        output = secorSchemaRegistryClient.decodeMessage("test-avr-topic", new byte[0]);
+        assertNull(output);
     }
 }


### PR DESCRIPTION
Hi Secor community!
We are using Secor for Avro messages with tombstone messaging - meaning we have null values in kafka (for more information: https://debezium.io/blog/tags/smt/#delete_records).
kafka-avro-serializer handles null as payload, so no problem there. The problem we are facing is that Secor converts null values into an empty byte array. In such cases, kafka-avro-serializer is trying to deserialize the data and we get "Error deserializing Avro message" as it is an empty byte array.

We fixed this issue by passing a null value to the serializer, and we now use the serializer results only if they are not null.

We would sincerely appreciate your assistance with this.