### PR TITLE
Use duration to match configuration parameter

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorKafkaClient.java
+++ b/src/main/java/com/pinterest/secor/common/SecorKafkaClient.java
@@ -82,7 +82,7 @@ public class SecorKafkaClient implements KafkaClient {
         int pollAttempts = 0;
         Message message = null;
         while (pollAttempts < MAX_READ_POLL_ATTEMPTS) {
-            Iterator<ConsumerRecord<byte[], byte[]>> records = kafkaConsumer.poll(Duration.ofMillis(mPollTimeout)).iterator();
+            Iterator<ConsumerRecord<byte[], byte[]>> records = kafkaConsumer.poll(Duration.ofSeconds(mPollTimeout)).iterator();
             if (!records.hasNext()) {
                 pollAttempts++;
             } else {


### PR DESCRIPTION
The configuration for this timeout is `config.getNewConsumerPollTimeoutSeconds();` which is also used in `SecorKafkaMessageIterator.java:55` as such.

This was causing issues, whereby the monitor poll would quickly timeout. Instead of having inconsistent usage, this seems the simplest approach.

Note that the `.poll()` method in `org.apache.kafka.clients.consumer.KafkaConsumer` is described in milliseconds.