### PR TITLE
Suppress 'downloading log messages' from mvn build and Travis-CI output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ TEST_HOME=/tmp/secor_test
 TEST_CONFIG=src/test/config
 JAR_FILE=target/secor-*-SNAPSHOT-bin.tar.gz
 MVN_PROFILE?=kafka-0.10.2.0
-MVN_OPTS=-DskipTests=true -Dmaven.javadoc.skip=true -P $(MVN_PROFILE)
+MVN_OPTS=-DskipTests=true -Dmaven.javadoc.skip=true -P $(MVN_PROFILE) -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+
 CONTAINERS=$(shell ls containers)
 
 build:


### PR DESCRIPTION
We are running out of log output limitation from Travis CI Build: https://travis-ci.org/pinterest/secor/jobs/563074090

Use the approache suggested by https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output to solve this problem