### PR TITLE
Suppress 'downloading log messages' from mvn build and Travis-CI output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,10 @@ build:
 	@mvn package $(MVN_OPTS) -P $(MVN_PROFILE)
 
 dependency_tree:
-	@mvn dependency:tree -P $(MVN_PROFILE)
+	@mvn dependency:tree $(MVN_OPTS) -P $(MVN_PROFILE)
 
 unit:
-	@mvn test -P $(MVN_PROFILE)
+	@mvn test $(MVN_OPTS) -P $(MVN_PROFILE)
 
 integration: build
 	@rm -rf $(TEST_HOME)


### PR DESCRIPTION
We are running out of log output limitation from Travis CI Build: https://travis-ci.org/pinterest/secor/jobs/563074090

Use the approache suggested by https://blogs.itemis.com/en/in-a-nutshell-removing-artifact-messages-from-maven-log-output to solve this problem

Suppress on all mvn build target