### PR TITLE
Added the ability to configure the topic-to-Avro-schema relationship manually (i.e. not using Confluent Schema Registry)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,9 @@
             <testResource>
                 <directory>src/test/config</directory>
             </testResource>
+            <testResource>
+                <directory>src/test/avro</directory>
+            </testResource>
         </testResources>
         <plugins>
             <plugin>

--- a/src/main/java/com/pinterest/secor/common/AvroSchemaRegistry.java
+++ b/src/main/java/com/pinterest/secor/common/AvroSchemaRegistry.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.pinterest.secor.common;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+public interface AvroSchemaRegistry {
+    GenericRecord deserialize(String topic, byte[] payload);
+
+    Schema getSchema(String topic);
+}

--- a/src/main/java/com/pinterest/secor/common/ConfigurableAvroSchemaRegistry.java
+++ b/src/main/java/com/pinterest/secor/common/ConfigurableAvroSchemaRegistry.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.pinterest.secor.common;
+
+import com.pinterest.secor.parser.AvroMessageParser;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.Decoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.specific.SpecificDatumReader;
+import org.apache.kafka.common.errors.SerializationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class ConfigurableAvroSchemaRegistry implements AvroSchemaRegistry {
+    private static final Logger LOG = LoggerFactory.getLogger(AvroMessageParser.class);
+    private final Map<String, Schema> schemas = new HashMap<>();
+    private final Map<String, SpecificDatumReader<GenericRecord>> readers = new HashMap<>();
+
+    public ConfigurableAvroSchemaRegistry(SecorConfig config) {
+        schemas.putAll(config.getAvroMessageSchema().entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> getAvroSchema(e.getValue()))));
+        readers.putAll(schemas.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> new SpecificDatumReader<>(e.getValue()))));
+    }
+
+    private Schema getAvroSchema(String path) {
+        Schema schema = null;
+        try {
+            schema = new Schema.Parser().parse(getClass().getResourceAsStream(path));
+        } catch (Exception ex) {
+            LOG.error("Exception getting schema for file " + path, ex);
+        }
+        return schema;
+    }
+
+    public GenericRecord deserialize(String topic, byte[] payload) {
+        GenericRecord record = null;
+        try {
+            Decoder decoder = DecoderFactory.get().binaryDecoder(payload, null);
+            record = readers.get(topic).read(null, decoder);
+        } catch (IOException ioe) {
+            throw new SerializationException("Error deserializing Avro message");
+        }
+        return record;
+    }
+
+    public Schema getSchema(String topic) {
+        return schemas.get(topic);
+    }
+}

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -26,11 +26,7 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Properties;
-import java.util.TimeZone;
+import java.util.*;
 
 /**
  * One-stop shop for Secor configuration options.
@@ -782,9 +778,13 @@ public class SecorConfig {
         }
         return map;
     }
-    
+
     public Map<String, String> getORCMessageSchema() {
         return getPropertyMapForPrefix("secor.orc.message.schema");
+    }
+
+    public Map<String, String> getAvroMessageSchema() {
+        return getPropertyMapForPrefix("secor.avro.message.schema");
     }
     
     public String getORCSchemaProviderClass(){

--- a/src/main/java/com/pinterest/secor/common/SecorSchemaRegistryClient.java
+++ b/src/main/java/com/pinterest/secor/common/SecorSchemaRegistryClient.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 
-public class SecorSchemaRegistryClient {
+public class SecorSchemaRegistryClient implements AvroSchemaRegistry {
 
     private static final Logger LOG = LoggerFactory.getLogger(SecorSchemaRegistryClient.class);
 
@@ -55,7 +55,7 @@ public class SecorSchemaRegistryClient {
         deserializer = new KafkaAvroDeserializer(schemaRegistryClient);
     }
 
-    public GenericRecord decodeMessage(String topic, byte[] message) {
+    public GenericRecord deserialize(String topic, byte[] message) {
         if (message.length == 0) {
             message = null;
         }

--- a/src/main/java/com/pinterest/secor/io/impl/AvroFileReaderWriterFactory.java
+++ b/src/main/java/com/pinterest/secor/io/impl/AvroFileReaderWriterFactory.java
@@ -18,14 +18,16 @@
  */
 package com.pinterest.secor.io.impl;
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-
-import com.google.protobuf.Message;
-import com.pinterest.secor.common.SecorSchemaRegistryClient;
-import com.pinterest.secor.util.FileUtil;
+import com.pinterest.secor.common.AvroSchemaRegistry;
+import com.pinterest.secor.common.LogFilePath;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.io.FileReader;
+import com.pinterest.secor.io.FileReaderWriterFactory;
+import com.pinterest.secor.io.FileWriter;
+import com.pinterest.secor.io.KeyValue;
+import com.pinterest.secor.util.AvroSchemaRegistryFactory;
+import com.pinterest.secor.util.AvroSerializer;
+import com.pinterest.secor.util.ParquetUtil;
 import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
@@ -33,30 +35,15 @@ import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.DatumWriter;
-import org.apache.avro.io.Encoder;
-import org.apache.avro.io.EncoderFactory;
 import org.apache.avro.specific.SpecificDatumReader;
 import org.apache.avro.specific.SpecificDatumWriter;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.compress.CompressionCodec;
-import org.apache.hadoop.io.compress.CompressionCodecFactory;
-import org.apache.parquet.avro.AvroParquetReader;
-import org.apache.parquet.avro.AvroParquetWriter;
-import org.apache.parquet.hadoop.ParquetReader;
-import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-
-import com.pinterest.secor.common.LogFilePath;
-import com.pinterest.secor.common.SecorConfig;
-import com.pinterest.secor.io.FileReader;
-import com.pinterest.secor.io.FileReaderWriterFactory;
-import com.pinterest.secor.io.FileWriter;
-import com.pinterest.secor.io.KeyValue;
-import com.pinterest.secor.util.ParquetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
 
 public class AvroFileReaderWriterFactory implements FileReaderWriterFactory {
 
@@ -65,14 +52,14 @@ public class AvroFileReaderWriterFactory implements FileReaderWriterFactory {
     protected final int pageSize;
     protected final boolean enableDictionary;
     protected final boolean validating;
-    protected SecorSchemaRegistryClient schemaRegistryClient;
+    protected AvroSchemaRegistry schemaRegistry;
 
     public AvroFileReaderWriterFactory(SecorConfig config) {
         blockSize = ParquetUtil.getParquetBlockSize(config);
         pageSize = ParquetUtil.getParquetPageSize(config);
         enableDictionary = ParquetUtil.getParquetEnableDictionary(config);
         validating = ParquetUtil.getParquetValidation(config);
-        schemaRegistryClient = new SecorSchemaRegistryClient(config);
+        schemaRegistry = AvroSchemaRegistryFactory.getSchemaRegistry(config);
     }
 
     @Override
@@ -83,16 +70,6 @@ public class AvroFileReaderWriterFactory implements FileReaderWriterFactory {
     @Override
     public FileWriter BuildFileWriter(LogFilePath logFilePath, CompressionCodec codec) throws Exception {
         return new AvroFileWriter(logFilePath, codec);
-    }
-
-    protected static byte[] serializeAvroRecord(SpecificDatumWriter<GenericRecord> writer, GenericRecord record) throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        Encoder encoder = EncoderFactory.get().directBinaryEncoder(out, null);
-        writer.write(record, encoder);
-        encoder.flush();
-        ByteBuffer serialized = ByteBuffer.allocate(out.toByteArray().length);
-        serialized.put(out.toByteArray());
-        return serialized.array();
     }
 
     protected class AvroFileReader implements FileReader {
@@ -106,7 +83,7 @@ public class AvroFileReaderWriterFactory implements FileReaderWriterFactory {
             file = new File(logFilePath.getLogFilePath());
             file.getParentFile().mkdirs();
             String topic = logFilePath.getTopic();
-            Schema schema = schemaRegistryClient.getSchema(topic);
+            Schema schema = schemaRegistry.getSchema(topic);
 
             DatumReader datumReader = new SpecificDatumReader(schema);
             try {
@@ -123,7 +100,7 @@ public class AvroFileReaderWriterFactory implements FileReaderWriterFactory {
         public KeyValue next() throws IOException {
             GenericRecord record = reader.next();
             if (record != null) {
-                return new KeyValue(offset++, serializeAvroRecord(writer, record));
+                return new KeyValue(offset++, AvroSerializer.serialize(writer, record));
             }
             return null;
         }
@@ -147,7 +124,7 @@ public class AvroFileReaderWriterFactory implements FileReaderWriterFactory {
             file.getParentFile().mkdirs();
             LOG.debug("Creating Brand new Writer for path {}", logFilePath.getLogFilePath());
             topic = logFilePath.getTopic();
-            Schema schema = schemaRegistryClient.getSchema(topic);
+            Schema schema = schemaRegistry.getSchema(topic);
             SpecificDatumWriter specificDatumWriter= new SpecificDatumWriter(schema);
             writer = new DataFileWriter(specificDatumWriter);
             writer.setCodec(getCodecFactory(codec));
@@ -172,7 +149,7 @@ public class AvroFileReaderWriterFactory implements FileReaderWriterFactory {
 
         @Override
         public void write(KeyValue keyValue) throws IOException {
-            GenericRecord record = schemaRegistryClient.decodeMessage(topic, keyValue.getValue());
+            GenericRecord record = schemaRegistry.deserialize(topic, keyValue.getValue());
             LOG.trace("Writing record {}", record);
             if (record != null){
                 writer.append(record);

--- a/src/main/java/com/pinterest/secor/parser/AvroIso8601MessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/AvroIso8601MessageParser.java
@@ -18,15 +18,14 @@
  */
 package com.pinterest.secor.parser;
 
+import com.pinterest.secor.common.AvroSchemaRegistry;
 import com.pinterest.secor.common.SecorConfig;
-import com.pinterest.secor.common.SecorSchemaRegistryClient;
 import com.pinterest.secor.message.Message;
-
+import com.pinterest.secor.util.AvroSchemaRegistryFactory;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.common.errors.SerializationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 
 import javax.xml.bind.DatatypeConverter;
 import java.util.Date;
@@ -40,18 +39,18 @@ public class AvroIso8601MessageParser extends TimestampedMessageParser {
     private static final Logger LOG = LoggerFactory.getLogger(AvroMessageParser.class);
 
     private final boolean m_timestampRequired;
-    protected final SecorSchemaRegistryClient schemaRegistryClient;
+    private final AvroSchemaRegistry schemaRegistry;
 
     public AvroIso8601MessageParser(SecorConfig config) {
         super(config);
-        schemaRegistryClient = new SecorSchemaRegistryClient(config);
+        schemaRegistry = AvroSchemaRegistryFactory.getSchemaRegistry(config);
         m_timestampRequired = config.isMessageTimestampRequired();
     }
 
     @Override
     public long extractTimestampMillis(final Message message) {
         try {
-            GenericRecord record = schemaRegistryClient.decodeMessage(message.getTopic(), message.getPayload());
+            GenericRecord record = schemaRegistry.deserialize(message.getTopic(), message.getPayload());
             if (record != null) {
                 Object fieldValue = record.get(mConfig.getMessageTimestampName());
                 if (fieldValue != null) {

--- a/src/main/java/com/pinterest/secor/util/AvroSchemaRegistryFactory.java
+++ b/src/main/java/com/pinterest/secor/util/AvroSchemaRegistryFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.pinterest.secor.util;
+
+import com.pinterest.secor.common.AvroSchemaRegistry;
+import com.pinterest.secor.common.ConfigurableAvroSchemaRegistry;
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.SecorSchemaRegistryClient;
+import org.apache.commons.lang.StringUtils;
+
+public class AvroSchemaRegistryFactory {
+    public static AvroSchemaRegistry getSchemaRegistry(SecorConfig config) {
+        if (!StringUtils.isBlank(config.getSchemaRegistryUrl())) {
+            return new SecorSchemaRegistryClient(config);
+        } else if (!config.getAvroMessageSchema().isEmpty()) {
+            return new ConfigurableAvroSchemaRegistry(config);
+        } else {
+            throw new RuntimeException("Schema registry URL or schema map must be specified");
+        }
+    }
+}

--- a/src/main/java/com/pinterest/secor/util/AvroSerializer.java
+++ b/src/main/java/com/pinterest/secor/util/AvroSerializer.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.pinterest.secor.util;
+
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.specific.SpecificDatumWriter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class AvroSerializer {
+    public static byte[] serialize(SpecificDatumWriter<GenericRecord> writer, GenericRecord record) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        Encoder encoder = EncoderFactory.get().directBinaryEncoder(out, null);
+        writer.write(record, encoder);
+        encoder.flush();
+        ByteBuffer serialized = ByteBuffer.allocate(out.toByteArray().length);
+        serialized.put(out.toByteArray());
+        return serialized.array();
+    }
+}

--- a/src/test/java/com/pinterest/secor/common/SecorSchemaRegistryClientTest.java
+++ b/src/test/java/com/pinterest/secor/common/SecorSchemaRegistryClientTest.java
@@ -20,7 +20,6 @@ package com.pinterest.secor.common;
 
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.serializers.KafkaAvroDecoder;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
@@ -35,7 +34,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.powermock.modules.junit4.PowerMockRunner;
+
 import java.util.Properties;
+
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -89,18 +90,18 @@ public class SecorSchemaRegistryClientTest extends TestCase {
                 .set("data_field_2", "hello")
                 .set("timestamp", 1467176316L)
                 .build();
-        GenericRecord output = secorSchemaRegistryClient.decodeMessage("test-avr-topic", avroSerializer.serialize("test-avr-topic", record1));
+        GenericRecord output = secorSchemaRegistryClient.deserialize("test-avr-topic", avroSerializer.serialize("test-avr-topic", record1));
         assertEquals(secorSchemaRegistryClient.getSchema("test-avr-topic"), schemaV1);
         assertEquals(output.get("data_field_1"), 1);
         assertEquals(output.get("timestamp"), 1467176315L);
 
-        output = secorSchemaRegistryClient.decodeMessage("test-avr-topic", avroSerializer.serialize("test-avr-topic", record2));
+        output = secorSchemaRegistryClient.deserialize("test-avr-topic", avroSerializer.serialize("test-avr-topic", record2));
         assertEquals(secorSchemaRegistryClient.getSchema("test-avr-topic"), schemaV2);
         assertEquals(output.get("data_field_1"), 1);
         assertTrue(StringUtils.equals((output.get("data_field_2")).toString(), "hello"));
         assertEquals(output.get("timestamp"), 1467176316L);
 
-        output = secorSchemaRegistryClient.decodeMessage("test-avr-topic", new byte[0]);
+        output = secorSchemaRegistryClient.deserialize("test-avr-topic", new byte[0]);
         assertNull(output);
     }
 }


### PR DESCRIPTION
We were interested in using Secor but couldn't without changing the code, as we're not using Confluent. These changes have enabled us to configure a map of topics to .avsc files (which must be on the classpath).