### PR TITLE
Upgrade jackson.core:jackson-databind to fix the folllowing security …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.8</version>
+                <version>2.9.9.2</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
…issue:

icom.fasterxml.jackson.core:jackson-databind vulnerabilities found in pom.xml on May 23

Remediation
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.9.2 or later. For example:
<dependency> <groupId>com.fasterxml.jackson.core</groupId> <artifactId>jackson-databind</artifactId> <version>[2.9.9.2,)</version> </dependency>
Always verify the validity and compatibility of suggestions with your codebase.

Details
CVE-2019-14379 More information
moderate severity
Vulnerable versions: < 2.9.9.2
Patched version: 2.9.9.2
SubTypeValidator.java in FasterXML jackson-databind before 2.9.9.2 mishandles default typing when ehcache is used, leading to remote code execution.