### PR TITLE
changing shell in docker-entrypoint.sh from bash to sh

### DIFF
--- a/src/main/scripts/docker-entrypoint.sh
+++ b/src/main/scripts/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 
 


### PR DESCRIPTION
The base image used in `/Dockerfile`, `openjdk:8` does not contain `/bin/bash`.