### PR TITLE
Fix test AvroParquetFileReaderWriterFactoryTest

### DIFF
--- a/src/test/avro/unittest.avsc
+++ b/src/test/avro/unittest.avsc
@@ -1,0 +1,9 @@
+{
+  "namespace": "mynamespace",
+  "type": "record",
+  "name": "event",
+  "fields": [
+    {"name": "field1", "type": "string"},
+    {"name": "field2", "type": "long"}
+  ]
+}


### PR DESCRIPTION
testAvroParquetReadWriteRoundTripWithoutSchemaRegistry failed because of missing avro schema