### PR TITLE
adding `exec` to the java command in the docker entrypoint

### DIFF
--- a/src/main/scripts/docker-entrypoint.sh
+++ b/src/main/scripts/docker-entrypoint.sh
@@ -130,6 +130,6 @@ cd /opt/secor
 DEFAULT_CLASSPATH="*:lib/*"
 CLASSPATH=${CLASSPATH:-$DEFAULT_CLASSPATH}
 
-java -Xmx${JVM_MEMORY:-512m} $JAVA_OPTS -ea -Dsecor_group=${SECOR_GROUP:-partition} -Dlog4j.configuration=file:${LOG4J_CONFIGURATION:-log4j.docker.properties} \
+exec java -Xmx${JVM_MEMORY:-512m} $JAVA_OPTS -ea -Dsecor_group=${SECOR_GROUP:-partition} -Dlog4j.configuration=file:${LOG4J_CONFIGURATION:-log4j.docker.properties} \
         -Dconfig=${CONFIG_FILE:-secor.prod.partition.properties} $SECOR_CONFIG \
         -cp $CLASSPATH ${SECOR_MAIN_CLASS:-com.pinterest.secor.main.ConsumerMain}


### PR DESCRIPTION
this makes Java PID 1 which is recommended so that SIGINT works properly