### PR TITLE
Query Avro schema from schema registry if it is missing

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorSchemaRegistryClient.java
+++ b/src/main/java/com/pinterest/secor/common/SecorSchemaRegistryClient.java
@@ -19,13 +19,16 @@
 package com.pinterest.secor.common;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +47,7 @@ public class SecorSchemaRegistryClient implements AvroSchemaRegistry {
             props.put("schema.registry.url", config.getSchemaRegistryUrl());
             schemaRegistryClient = new CachedSchemaRegistryClient(config.getSchemaRegistryUrl(), 30);
             init(config);
-        } catch (Exception e){
+        } catch (Exception e) {
             LOG.error("Error initalizing schema registry", e);
             throw new RuntimeException(e);
         }
@@ -67,10 +70,27 @@ public class SecorSchemaRegistryClient implements AvroSchemaRegistry {
         return record;
     }
 
+    /**
+     * Get Avro schema of a topic. It uses the cache that either is set by calling {@link #deserialize(String, byte[])}
+     * or querying this method to avoid hitting Schema Registry for each call.
+     * It uses standard "subject name" strategy and it is topic_name-value.
+     *
+     * @param topic a Kafka topic to query the schema for
+     * @return Schema object for the topic
+     * @throws IllegalStateException if there is no schema registered for this topic or it is not able to fetch it
+     */
     public Schema getSchema(String topic) {
         Schema schema = schemas.get(topic);
         if (schema == null) {
-            throw new IllegalStateException("Avro schema not found for topic " + topic);
+            try {
+                SchemaMetadata schemaMetadata = schemaRegistryClient.getLatestSchemaMetadata(topic + "-value");
+                schema = schemaRegistryClient.getByID(schemaMetadata.getId());
+                schemas.put(topic, schema);
+            } catch (IOException e) {
+                throw new IllegalStateException("Unable to get Avro schema not found for topic " + topic);
+            } catch (RestClientException e) {
+                throw new IllegalStateException("Avro schema not found for topic " + topic);
+            }
         }
         return schema;
     }


### PR DESCRIPTION
As mentioned https://github.com/pinterest/secor/issues/894, secor fails if

- `secor.file.reader.writer.factory=com.pinterest.secor.io.impl.AvroParquetFileReaderWriterFactory` 
- `kafka.useTimestamp=true`

The writer is going to ask `SecorSchemaRegistryClient` for Avro schema for the writer. But that only has the schema in the cache if there has been a call for `decodeMessage`. However, if we use the message timestamp, it won't need to decode the message.

I updated the code to query the schema registry in order to update the cache. It uses the standard subject name for a Kafka topic as "kafka_topic-value" to query the schema.