### PR TITLE
Produce fat JAR (with all dependencies included)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,6 +443,10 @@
                             <descriptors>
                                 <descriptor>src/main/assembly/secor.xml</descriptor>
                             </descriptors>
+                            <!-- get all project dependencies -->
+                            <descriptorRefs>
+                                <descriptorRef>jar-with-dependencies</descriptorRef>
+                            </descriptorRefs>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This modifies the `mvn package` command to produce a fat (uber) `.jar` file that includes all dependencies, so that one can simply drop a single `.jar` file to run secor. `mvn package` (or `make build`) command will make `secor-${VERSION}-SNAPSHOT-jar-with-dependencies.jar` under `targets` directory.