### PR TITLE
Reject non-string keys

### DIFF
--- a/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
+++ b/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
@@ -184,7 +184,7 @@ public class VectorColumnFiller {
         private void assertKeyType(TypeDescription schema) {
             TypeDescription keyType = schema.getChildren().get(0);
             String keyTypeName = keyType.getCategory().getName();
-            if (!keyTypeName.equals("string")) {
+            if (!keyTypeName.equalsIgnoreCase("string")) {
                 throw new IllegalArgumentException(
                         String.format("Unsupported key type: %s", keyTypeName));
             }

--- a/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
+++ b/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.util.List;
-import java.util.Set;
 
 /**
  * 
@@ -166,13 +165,13 @@ public class VectorColumnFiller {
     }
 
     static class MapColumnConverter implements JsonConverter {
-        private JsonConverter[] childrenConverters;
+        private JsonConverter[] childConverters;
 
         public MapColumnConverter(TypeDescription schema) {
-            List<TypeDescription> kids = schema.getChildren();
-            childrenConverters = new JsonConverter[kids.size()];
-            for (int c = 0; c < childrenConverters.length; ++c) {
-                childrenConverters[c] = createConverter(kids.get(c));
+            List<TypeDescription> childTypes = schema.getChildren();
+            childConverters = new JsonConverter[childTypes.size()];
+            for (int c = 0; c < childConverters.length; ++c) {
+                childConverters[c] = createConverter(childTypes.get(c));
             }
         }
 
@@ -192,8 +191,8 @@ public class VectorColumnFiller {
 
                 int i = 0;
                 for (String key : obj.keySet()) {
-                    childrenConverters[0].convert(new JsonPrimitive(key), vector.keys, (int) vector.offsets[row] + i);
-                    childrenConverters[1].convert(obj.get(key), vector.values, (int) vector.offsets[row] + i);
+                    childConverters[0].convert(new JsonPrimitive(key), vector.keys, (int) vector.offsets[row] + i);
+                    childConverters[1].convert(obj.get(key), vector.values, (int) vector.offsets[row] + i);
                     i++;
                 }
             }

--- a/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
+++ b/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
@@ -182,6 +182,11 @@ public class VectorColumnFiller {
          * as keys.
          */
         private void assertKeyType(TypeDescription schema) {
+            // NOTE: It may be tempting to ensure that schema.getChildren() returns at least one child here, but the
+            // validity of an ORC schema is ensured by TypeDescription. Malformed ORC schema could be a concern.
+            // For example, an ORC schema of `map<>` may produce a TypeDescription instance with no child. However,
+            // TypeDescription.fromString() rejects any malformed ORC schema and therefore we may assume only valid
+            // ORC schema will make to this point.
             TypeDescription keyType = schema.getChildren().get(0);
             String keyTypeName = keyType.getCategory().getName();
             if (!keyTypeName.equalsIgnoreCase("string")) {

--- a/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
+++ b/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
@@ -168,10 +168,25 @@ public class VectorColumnFiller {
         private JsonConverter[] childConverters;
 
         public MapColumnConverter(TypeDescription schema) {
+            assertKeyType(schema);
+
             List<TypeDescription> childTypes = schema.getChildren();
             childConverters = new JsonConverter[childTypes.size()];
             for (int c = 0; c < childConverters.length; ++c) {
                 childConverters[c] = createConverter(childTypes.get(c));
+            }
+        }
+
+        /**
+         * Rejects non-string keys. This is a limitation imposed by JSON specifications that only allows strings
+         * as keys.
+         */
+        private void assertKeyType(TypeDescription schema) {
+            TypeDescription keyType = schema.getChildren().get(0);
+            String keyTypeName = keyType.getCategory().getName();
+            if (!keyTypeName.equals("string")) {
+                throw new IllegalArgumentException(
+                        String.format("Unsupported key type: %s", keyTypeName));
             }
         }
 

--- a/src/test/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactoryTest.java
+++ b/src/test/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactoryTest.java
@@ -205,7 +205,7 @@ public class JsonORCFileReaderWriterFactoryTest {
         fileReader.close();
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testWithNonStringKeys() throws Exception {
         PropertiesConfiguration properties = new PropertiesConfiguration();
         properties.setProperty("secor.orc.schema.provider", DEFAULT_ORC_SCHEMA_PROVIDER);
@@ -219,11 +219,5 @@ public class JsonORCFileReaderWriterFactoryTest {
         KeyValue written1 = new KeyValue(90001, "{\"kvs\":{1:2,3:4}}".getBytes());
         fileWriter.write(written1);
         fileWriter.close();
-
-        FileReader fileReader = factory.BuildFileReader(tempLogFilePath, codec);
-        KeyValue read1 = fileReader.next();
-        fileReader.close();
-
-        assertArrayEquals(written1.getValue(), read1.getValue());
     }
 }

--- a/src/test/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactoryTest.java
+++ b/src/test/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactoryTest.java
@@ -204,4 +204,26 @@ public class JsonORCFileReaderWriterFactoryTest {
         }
         fileReader.close();
     }
+
+    @Test
+    public void testWithNonStringKeys() throws Exception {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty("secor.orc.schema.provider", DEFAULT_ORC_SCHEMA_PROVIDER);
+        properties.setProperty("secor.orc.message.schema.test-nonstring-keys", "struct<kvs:map<int\\,int>>");
+
+        SecorConfig config = new SecorConfig(properties);
+        JsonORCFileReaderWriterFactory factory = new JsonORCFileReaderWriterFactory(config);
+        LogFilePath tempLogFilePath = getTempLogFilePath("test-nonstring-keys");
+
+        FileWriter fileWriter = factory.BuildFileWriter(tempLogFilePath, codec);
+        KeyValue written1 = new KeyValue(90001, "{\"kvs\":{1:2,3:4}}".getBytes());
+        fileWriter.write(written1);
+        fileWriter.close();
+
+        FileReader fileReader = factory.BuildFileReader(tempLogFilePath, codec);
+        KeyValue read1 = fileReader.next();
+        fileReader.close();
+
+        assertArrayEquals(written1.getValue(), read1.getValue());
+    }
 }


### PR DESCRIPTION
As far as I understand, JSON only allows string keys. However, the current implementation of `MapColumnConverter` allows arbitrary types as map keys which potentially cause issues for `JsonConverter`. This PR adds a safeguard that rejects non-string map keys.