### PR TITLE
Message offset adjust ticket #1010

### DIFF
--- a/src/main/java/com/pinterest/secor/common/OffsetTracker.java
+++ b/src/main/java/com/pinterest/secor/common/OffsetTracker.java
@@ -36,6 +36,10 @@ public class OffsetTracker {
     private HashMap<TopicPartition, Long> mCommittedOffsetCount;
 
     public OffsetTracker() {
+        reInitiateOffset();
+    }
+
+    public void reInitiateOffset() {
         mLastSeenOffset = new HashMap<TopicPartition, Long>();
         mCommittedOffsetCount = new HashMap<TopicPartition, Long>();
         mFirstSeendOffset = new HashMap<TopicPartition, Long>();
@@ -52,15 +56,14 @@ public class OffsetTracker {
     public long setLastSeenOffset(TopicPartition topicPartition, long offset) {
         long lastSeenOffset = getLastSeenOffset(topicPartition);
         mLastSeenOffset.put(topicPartition, offset);
-        if (lastSeenOffset + 1 != offset) {
-            if (lastSeenOffset >= 0) {
-                LOG.warn("offset for topic {} partition {} changed from {} to {}",
-                        topicPartition.getTopic(),topicPartition.getPartition(),lastSeenOffset, offset);
-            } else {
+        if (offset < lastSeenOffset + 1) {
+            LOG.warn("offset for topic {} partition {} goes back from {} to {}",
+                    topicPartition.getTopic(), topicPartition.getPartition(), lastSeenOffset, offset);
+
+        } else if (lastSeenOffset < 0) {
                 LOG.info("starting to consume topic {} partition {} from offset {}",
                         topicPartition.getTopic(),topicPartition.getPartition(),offset);
             }
-        }
         if (mFirstSeendOffset.get(topicPartition) == null) {
             mFirstSeendOffset.put(topicPartition, offset);
         }

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -49,7 +49,7 @@ public class MessageReader {
     protected final int mCheckMessagesPerSecond;
     protected int mNMessages;
 
-    public MessageReader(SecorConfig config, OffsetTracker offsetTracker) throws
+    public MessageReader(SecorConfig config, OffsetTracker offsetTracker, KafkaMessageIterator kafkaMessageIterator) throws
             UnknownHostException {
         mConfig = config;
         mOffsetTracker = offsetTracker;
@@ -57,7 +57,7 @@ public class MessageReader {
         StatsUtil.setLabel("secor.kafka.consumer.id", IdUtil.getConsumerId());
         mTopicPartitionForgetSeconds = mConfig.getTopicPartitionForgetSeconds();
         mCheckMessagesPerSecond = mConfig.getMessagesPerSecond() / mConfig.getConsumerThreads();
-        mKafkaMessageIterator = KafkaMessageIteratorFactory.getIterator(mConfig.getKafkaMessageIteratorClass(), mConfig);
+        mKafkaMessageIterator = kafkaMessageIterator;
     }
 
     private void updateAccessTime(TopicPartition topicPartition) {

--- a/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
@@ -24,6 +24,9 @@ import com.pinterest.secor.common.SecorConfig;
 import com.pinterest.secor.common.ZookeeperConnector;
 import com.pinterest.secor.message.Message;
 import com.pinterest.secor.message.MessageHeader;
+import com.pinterest.secor.rebalance.RebalanceHandler;
+import com.pinterest.secor.rebalance.RebalanceSubscriber;
+import com.pinterest.secor.rebalance.SecorConsumerRebalanceListener;
 import com.pinterest.secor.util.IdUtil;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -40,18 +43,14 @@ import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-public class SecorKafkaMessageIterator implements KafkaMessageIterator {
+public class SecorKafkaMessageIterator implements KafkaMessageIterator, RebalanceSubscriber {
     private static final Logger LOG = LoggerFactory.getLogger(SecorKafkaMessageIterator.class);
     private KafkaConsumer<byte[], byte[]> mKafkaConsumer;
     private Deque<ConsumerRecord<byte[], byte[]>> mRecordsBatch;
@@ -119,67 +118,9 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator {
         optionalConfig(config.getSslTruststoreType(), conf -> props.put("ssl.truststore.type", conf));
         optionalConfig(config.getNewConsumerPartitionAssignmentStrategyClass(), conf -> props.put("partition.assignment.strategy", conf));
 
-        String dualCommitEnabled = config.getDualCommitEnabled();
-        String offsetStorage = config.getOffsetsStorage();
-        final boolean skipZookeeperOffsetSeek = offsetStorage.equals("kafka") && dualCommitEnabled.equals("true");
-
         mZookeeperConnector = new ZookeeperConnector(config);
         mRecordsBatch = new ArrayDeque<>();
         mKafkaConsumer = new KafkaConsumer<>(props);
-        ConsumerRebalanceListener reBalanceListener = new ConsumerRebalanceListener() {
-            @Override
-            public void onPartitionsRevoked(Collection<TopicPartition> assignedPartitions) {
-                for (TopicPartition topicPartition : assignedPartitions) {
-                    LOG.debug("re-balance will happen for assigned topic partition {}", topicPartition);
-                }
-            }
-
-            @Override
-            public void onPartitionsAssigned(Collection<TopicPartition> collection) {
-                if (skipZookeeperOffsetSeek) {
-                    LOG.debug("offset storage set to kafka. Skipping reading offsets from zookeeper");
-                    return;
-                }
-                Map<TopicPartition, Long> committedOffsets = getCommittedOffsets(collection);
-                committedOffsets.forEach(((topicPartition, offset) -> {
-                    if (offset == -1) {
-                        if (offsetResetConfig.equals("earliest")) {
-                            mKafkaConsumer.seekToBeginning(Collections.singleton(topicPartition));
-                        } else if (offsetResetConfig.equals("latest")) {
-                            mKafkaConsumer.seekToEnd(Collections.singleton(topicPartition));
-                        }
-                    } else {
-                        LOG.debug("Seeking {} to offset {}", topicPartition, Math.max(0, offset));
-                        mKafkaConsumer.seek(topicPartition, Math.max(0, offset));
-                    }
-                }));
-            }
-        };
-
-        String[] subscribeList = config.getKafkaTopicList();
-        if (Strings.isNullOrEmpty(subscribeList[0])) {
-            mKafkaConsumer.subscribe(Pattern.compile(config.getKafkaTopicFilter()), reBalanceListener);
-        } else {
-            mKafkaConsumer.subscribe(Arrays.asList(subscribeList), reBalanceListener);
-        }
-    }
-
-    private Map<TopicPartition, Long> getCommittedOffsets(Collection<TopicPartition> assignment) {
-        Map<TopicPartition, Long> committedOffsets = new HashMap<>();
-
-        for (TopicPartition topicPartition : assignment) {
-            com.pinterest.secor.common.TopicPartition secorTopicPartition =
-                    new com.pinterest.secor.common.TopicPartition(topicPartition.topic(), topicPartition.partition());
-            try {
-                long committedOffset = mZookeeperConnector.getCommittedOffsetCount(secorTopicPartition);
-                committedOffsets.put(topicPartition, committedOffset);
-            } catch (Exception e) {
-                LOG.trace("Unable to fetch committed offsets from zookeeper", e);
-                throw new RuntimeException(e);
-            }
-        }
-
-        return committedOffsets;
     }
 
     @Override
@@ -197,5 +138,27 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator {
 
     private void optionalConfig(String maybeConf, Consumer<String> configConsumer) {
         Optional.ofNullable(maybeConf).filter(conf -> !conf.isEmpty()).ifPresent(configConsumer);
+    }
+
+    @Override
+    public void subscribe(RebalanceHandler handler, SecorConfig config) {
+        ConsumerRebalanceListener reBalanceListener = new SecorConsumerRebalanceListener(mKafkaConsumer, mZookeeperConnector, getSkipZookeeperOffsetSeek(config), config.getNewConsumerAutoOffsetReset(), handler);
+        ;
+
+        String[] subscribeList = config.getKafkaTopicList();
+        if (Strings.isNullOrEmpty(subscribeList[0])) {
+            mKafkaConsumer.subscribe(Pattern.compile(config.getKafkaTopicFilter()), reBalanceListener);
+        } else {
+            mKafkaConsumer.subscribe(Arrays.asList(subscribeList), reBalanceListener);
+        }
+    }
+
+
+    private boolean getSkipZookeeperOffsetSeek(SecorConfig config) {
+
+        String dualCommitEnabled = config.getDualCommitEnabled();
+        String offsetStorage = config.getOffsetsStorage();
+        return offsetStorage.equals("kafka") && dualCommitEnabled.equals("true");
+
     }
 }

--- a/src/main/java/com/pinterest/secor/rebalance/RebalanceHandler.java
+++ b/src/main/java/com/pinterest/secor/rebalance/RebalanceHandler.java
@@ -1,0 +1,49 @@
+package com.pinterest.secor.rebalance;
+
+import com.pinterest.secor.common.FileRegistry;
+import com.pinterest.secor.common.OffsetTracker;
+import com.pinterest.secor.common.TopicPartition;
+import com.pinterest.secor.uploader.Uploader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+
+public class RebalanceHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SecorConsumerRebalanceListener.class);
+
+    private Uploader uploader;
+
+    private FileRegistry mfileRegistery;
+
+    private OffsetTracker mOffsetTracker;
+
+    public RebalanceHandler(Uploader uploader, FileRegistry mfileRegistery, OffsetTracker mOffsetTracker) {
+        this.uploader = uploader;
+        this.mfileRegistery = mfileRegistery;
+        this.mOffsetTracker = mOffsetTracker;
+    }
+
+    public void uploadOnRevoke(Collection<TopicPartition> assignedPartitions) {
+        try {
+            uploader.applyPolicy(true);
+        } catch (Exception e) {
+            LOG.info("re-balance force upload failed, cleaning local files now");
+        } finally {
+            for (TopicPartition tp : assignedPartitions) {
+                forceCleanUp(tp);
+            }
+            mOffsetTracker.reInitiateOffset();
+        }
+    }
+
+    private void forceCleanUp(TopicPartition topicPartition) {
+        try {
+            mfileRegistery.deleteTopicPartition(topicPartition);
+        } catch (Exception e) {
+            LOG.warn("failure when deleting local files for topic {} and partition {} need to delete it manually", topicPartition.getTopic(), topicPartition.getPartition(), e);
+        }
+    }
+
+}

--- a/src/main/java/com/pinterest/secor/rebalance/RebalanceSubscriber.java
+++ b/src/main/java/com/pinterest/secor/rebalance/RebalanceSubscriber.java
@@ -1,0 +1,7 @@
+package com.pinterest.secor.rebalance;
+
+import com.pinterest.secor.common.SecorConfig;
+
+public interface RebalanceSubscriber {
+    void subscribe(RebalanceHandler handler, SecorConfig config);
+}

--- a/src/main/java/com/pinterest/secor/rebalance/SecorConsumerRebalanceListener.java
+++ b/src/main/java/com/pinterest/secor/rebalance/SecorConsumerRebalanceListener.java
@@ -1,0 +1,92 @@
+package com.pinterest.secor.rebalance;
+
+import com.pinterest.secor.common.ZookeeperConnector;
+import com.pinterest.secor.util.StatsUtil;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class SecorConsumerRebalanceListener implements ConsumerRebalanceListener {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SecorConsumerRebalanceListener.class);
+
+    private KafkaConsumer<byte[], byte[]> mKafkaConsumer;
+
+    private ZookeeperConnector mZookeeperConnector;
+
+    private boolean skipZookeeperOffsetSeek;
+
+    private String offsetResetConfig;
+
+    private RebalanceHandler handler;
+
+
+    public SecorConsumerRebalanceListener(KafkaConsumer<byte[], byte[]> mKafkaConsumer, ZookeeperConnector mZookeeperConnector, boolean skipZookeeperOffsetSeek, String offsetResetConfig, RebalanceHandler handler) {
+        this.mKafkaConsumer = mKafkaConsumer;
+        this.mZookeeperConnector = mZookeeperConnector;
+        this.skipZookeeperOffsetSeek = skipZookeeperOffsetSeek;
+        this.offsetResetConfig = offsetResetConfig;
+        this.handler = handler;
+    }
+
+    @Override
+    public void onPartitionsRevoked(Collection<TopicPartition> assignedPartitions) {
+        // Here we do a force upload/commit so the other consumer take over partition(s) later don't need to rewrite the same messages
+        LOG.info("re-balance starting, forcing uploading current assigned partitions {}", assignedPartitions);
+
+        List<com.pinterest.secor.common.TopicPartition> tps = assignedPartitions.stream().map(p -> new com.pinterest.secor.common.TopicPartition(p.topic(), p.partition())).collect(Collectors.toList());
+        tps.stream().map(p -> p.getTopic()).collect(Collectors.toSet()).forEach(topic -> StatsUtil.incr("secor.consumer_rebalance_count." + topic));
+        handler.uploadOnRevoke(tps);
+    }
+
+    @Override
+    public void onPartitionsAssigned(Collection<TopicPartition> collection) {
+        if (skipZookeeperOffsetSeek) {
+            LOG.debug("offset storage set to kafka. Skipping reading offsets from zookeeper");
+            return;
+        }
+        Map<TopicPartition, Long> committedOffsets = getCommittedOffsets(collection);
+        committedOffsets.forEach(((topicPartition, offset) -> {
+            if (offset == -1) {
+                if (offsetResetConfig.equals("earliest")) {
+                    mKafkaConsumer.seekToBeginning(Collections.singleton(topicPartition));
+                } else if (offsetResetConfig.equals("latest")) {
+                    mKafkaConsumer.seekToEnd(Collections.singleton(topicPartition));
+                }
+            } else {
+                long committedOffset = Math.max(0, offset);
+                LOG.info("Seeking {} to offset {} after partition assigned", topicPartition, committedOffset);
+                mKafkaConsumer.seek(topicPartition, committedOffset);
+            }
+        }));
+    }
+
+    private Map<TopicPartition, Long> getCommittedOffsets(Collection<TopicPartition> assignment) {
+        Map<TopicPartition, Long> committedOffsets = new HashMap<>();
+
+        for (TopicPartition topicPartition : assignment) {
+            com.pinterest.secor.common.TopicPartition secorTopicPartition =
+                    new com.pinterest.secor.common.TopicPartition(topicPartition.topic(), topicPartition.partition());
+            try {
+                long committedOffset = mZookeeperConnector.getCommittedOffsetCount(secorTopicPartition);
+                committedOffsets.put(topicPartition, committedOffset);
+            } catch (Exception e) {
+                LOG.trace("Unable to fetch committed offsets from zookeeper", e);
+                throw new RuntimeException(e);
+            }
+        }
+
+        return committedOffsets;
+    }
+
+
+}

--- a/src/test/java/com/pinterest/secor/rebalance/RebalanceHandlerTest.java
+++ b/src/test/java/com/pinterest/secor/rebalance/RebalanceHandlerTest.java
@@ -1,0 +1,53 @@
+package com.pinterest.secor.rebalance;
+
+import com.pinterest.secor.common.FileRegistry;
+import com.pinterest.secor.common.OffsetTracker;
+import com.pinterest.secor.common.TopicPartition;
+import com.pinterest.secor.uploader.Uploader;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+
+public class RebalanceHandlerTest extends TestCase {
+
+    private RebalanceHandler testee;
+
+    private Uploader uploader;
+
+    private FileRegistry fileRegistry;
+
+    private OffsetTracker offsetTracker;
+
+    @Override
+    public void setUp() throws Exception {
+        fileRegistry = mock(FileRegistry.class);
+        offsetTracker = mock(OffsetTracker.class);
+        uploader = mock(Uploader.class);
+        testee = new RebalanceHandler(uploader, fileRegistry, offsetTracker);
+
+    }
+
+    @Test
+    public void testRebalanceHandlerInvoke() throws Exception {
+
+        List<TopicPartition> topicPartitions = new LinkedList<>();
+        topicPartitions.add(new TopicPartition("some_topic", 0));
+        topicPartitions.add(new TopicPartition("some_topic", 1));
+        testee.uploadOnRevoke(topicPartitions);
+
+
+        Mockito.verify(uploader, times(1)).applyPolicy(true);
+        Mockito.verify(fileRegistry, times(2)).deleteTopicPartition(any(TopicPartition.class));
+        Mockito.verify(offsetTracker, times(1)).reInitiateOffset();
+
+
+    }
+}


### PR DESCRIPTION
This is for ticket id #1010 regarding offset.

The offset validation logic is refactored a bit to ensure working for both transactional and non-transactional mode. Since:
1) in transactional mode messages are not +1 between messages
2) in non-transaction mode, there might be very minor chances a message get delivered more than once due to retrying.

Now the offset logic in message writer works:  If the current processing message offset is not greater than "last seen offset" (messages have written), it means there are rebalances and/or the broker is replaying message from last committed offset/failure point. Since the messages before offsets are written, we can safely trim those message to remove duplicates. 

The existing commit offset validation logic in upload class remains intact . The existing logic ensures that after rebalances, if another consumer has made progress on a same topic/partition, we either trims those files or trim corresponding completed offset.
