### PR TITLE
Follow-up of #1011 (Support union types)

### DIFF
--- a/src/main/java/com/pinterest/secor/util/orc/JsonFieldFiller.java
+++ b/src/main/java/com/pinterest/secor/util/orc/JsonFieldFiller.java
@@ -107,8 +107,10 @@ public class JsonFieldFiller {
                 setUnion(writer, (UnionColumnVector) vector, schema, row);
                 break;
             case BINARY:
-                // printBinary(writer, (BytesColumnVector) vector, row);
-                break;
+                // To prevent similar mistakes like the on described in https://github.com/pinterest/secor/pull/1018,
+                // it would be better to explicitly throw an exception here rather than ignore the incoming values,
+                // which causes silent failures in a later stage.
+                throw new UnsupportedOperationException();
             case MAP:
                 setMap(writer, (MapColumnVector) vector, schema, row);
                 break;

--- a/src/main/java/com/pinterest/secor/util/orc/JsonFieldFiller.java
+++ b/src/main/java/com/pinterest/secor/util/orc/JsonFieldFiller.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.orc.TypeDescription;
@@ -103,7 +104,7 @@ public class JsonFieldFiller {
                 setStruct(writer, (StructColumnVector) vector, schema, row);
                 break;
             case UNION:
-                // printUnion(writer, (UnionColumnVector) vector, schema, row);
+                setUnion(writer, (UnionColumnVector) vector, schema, row);
                 break;
             case BINARY:
                 // printBinary(writer, (BytesColumnVector) vector, row);
@@ -155,5 +156,18 @@ public class JsonFieldFiller {
             setValue(writer, vector.values, schemaChildren.get(1), (int) offset + i);
         }
         writer.endObject();
+    }
+
+    /**
+     * Writes a single row of union type as a JSON object.
+     *
+     * @throws JSONException
+     */
+    private static void setUnion(JSONWriter writer, UnionColumnVector vector,
+                                 TypeDescription schema, int row) throws JSONException {
+        int tag = vector.tags[row];
+        List<TypeDescription> schemaChildren = schema.getChildren();
+        ColumnVector columnVector = vector.fields[tag];
+        setValue(writer, columnVector, schemaChildren.get(tag), row);
     }
 }

--- a/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
+++ b/src/main/java/com/pinterest/secor/util/orc/VectorColumnFiller.java
@@ -326,6 +326,7 @@ public class VectorColumnFiller {
 
                 int vectorIndex = converterInfo.getVectorIndex();
                 JsonConverter converter = converterInfo.getConverter();
+                vector.tags[row] = vectorIndex;
                 converter.convert(value, vector.fields[vectorIndex], row);
             } else {
                 // It would be great to support non-primitive types in union type.

--- a/src/test/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactoryTest.java
+++ b/src/test/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactoryTest.java
@@ -70,17 +70,21 @@ public class JsonORCFileReaderWriterFactoryTest {
         FileWriter fileWriter = factory.BuildFileWriter(tempLogFilePath, codec);
         KeyValue written1 = new KeyValue(10001, "{\"values\":\"stringvalue\"}".getBytes());
         KeyValue written2 = new KeyValue(10002, "{\"values\":1234}".getBytes());
+        KeyValue written3 = new KeyValue(10003, "{\"values\":null}".getBytes());
         fileWriter.write(written1);
         fileWriter.write(written2);
+        fileWriter.write(written3);
         fileWriter.close();
 
         FileReader fileReader = factory.BuildFileReader(tempLogFilePath, codec);
         KeyValue read1 = fileReader.next();
         KeyValue read2 = fileReader.next();
+        KeyValue read3 = fileReader.next();
         fileReader.close();
 
         assertArrayEquals(written1.getValue(), read1.getValue());
         assertArrayEquals(written2.getValue(), read2.getValue());
+        assertArrayEquals(written3.getValue(), read3.getValue());
     }
 
     @Test(expected = UnsupportedOperationException.class)

--- a/src/test/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactoryTest.java
+++ b/src/test/java/com/pinterest/secor/io/impl/JsonORCFileReaderWriterFactoryTest.java
@@ -73,6 +73,14 @@ public class JsonORCFileReaderWriterFactoryTest {
         fileWriter.write(written1);
         fileWriter.write(written2);
         fileWriter.close();
+
+        FileReader fileReader = factory.BuildFileReader(tempLogFilePath, codec);
+        KeyValue read1 = fileReader.next();
+        KeyValue read2 = fileReader.next();
+        fileReader.close();
+
+        assertArrayEquals(written1.getValue(), read1.getValue());
+        assertArrayEquals(written2.getValue(), read2.getValue());
     }
 
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
#1011 was missing a critical part: writing union type rows as JSON objects. `FileWriter` works okay with union types, but when we try to read values via `FileReader` it sees incomplete JSON data.

To illustrate the problem a bit further, `FileWriter` doesn't quite finish writing ORC data as JSON because `JsonFieldFiller` is not fully implemented to cope with union types.

```
            case UNION:
                // printUnion(writer, (UnionColumnVector) vector, schema, row);
                break;
```

And thus `FileReader` would encounter incomplete JSON values like:

```
{"values":}
```

This PR addresses the issue.