### PR TITLE
Use timestamp from Kafka message header

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/KafkaTimestampParser.java
+++ b/src/main/java/com/pinterest/secor/parser/KafkaTimestampParser.java
@@ -1,0 +1,15 @@
+package com.pinterest.secor.parser;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.message.Message;
+
+public class KafkaTimestampParser extends TimestampedMessageParser {
+    public KafkaTimestampParser(SecorConfig config) {
+        super(config);
+    }
+
+    @Override
+    public long extractTimestampMillis(Message message) {
+        return message.getTimestamp();
+    }
+}


### PR DESCRIPTION
Although `JsonMessageParser` provides a neat way to extract a timestamp column from JSON messages, my team faced a unique set of challenges. To give you a little bit of background, we are consuming about 20-30 Kafka topics with a single *deployment* (multiple Secor instances,  identical configs). We would like to load data to S3 by partitioning records by date, and we would like to use the timestamp in Kafka message headers for this purpose.

I understand `TimestampedMessageParser`'s `getTimestampMills()` could extract the Kafka message timestamp as follows:

```
    public long getTimestampMillis(Message message) throws Exception {
        return (mUseKafkaTimestamp) ? toMillis(message.getTimestamp()) : extractTimestampMillis(message);
    }
```

However, `JsonMessageParser` overwrites it with its own implementation, and there is no way to retrieve the value of `message.getTimestamp()`.

```
    @Override
    public long extractTimestampMillis(final Message message) {
        JSONObject jsonObject = (JSONObject) JSONValue.parse(message.getPayload());
        if (jsonObject != null) {
            Object fieldValue = getJsonFieldValue(jsonObject);
            if (fieldValue != null) {
                return toMillis(Double.valueOf(fieldValue.toString()).longValue());
            }
        } else if (m_timestampRequired) {
            throw new RuntimeException("Missing timestamp field for message: " + message);
        }
        return 0;
    }
```

I've also looked at https://github.com/pinterest/secor/issues/455, but it does not seems like `kafka.message.timestamp.className` has any effect in `JsonMessageParser`.

Hence, I would like to propose this as a quick solution. If you think we'd better off fixing `JsonMessageParser.extractTimestampMillis()` somehow, please let me know. Thanks.