### PR TITLE
Upgrade guava to fix NoSuchMethodError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,7 +314,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>20.0</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>


### PR DESCRIPTION
Fix for issue the [1168](https://github.com/pinterest/secor/issues/1168)

Method ByteStreams.exhaust is only available in versions higher than [20.0](https://guava.dev/releases/20.0/api/docs/com/google/common/io/ByteStreams.html#exhaust-java.io.InputStream-).