### PR TITLE
Update maven-javadoc-plugin version to work with higher version of Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,7 +569,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.1.2</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
I am using Java 14 now which doesn't have 3.1.2 maven plugin