### PR TITLE
Add support to upload last seen offset onto ZK to solve the determini…

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -462,6 +462,9 @@ secor.upload.minute_mark=0
 # appropriate grace period to allow a full upload before a forced termination.
 secor.upload.on.shutdown=false
 
+# If true, uploads lastSeen offset onto ZK, see https://github.com/pinterest/secor/issues/600 for details
+secor.upload.secor.upload.last.seen.offset=false
+
 # If true, uploads are entirely deterministic, which can avoid some race conditions
 # which can lead to messages being backed up multiple times. This is incompatible with
 # secor.upload.on.shutdown=true, and ignores the values of secor.max.file.size.bytes,

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -277,6 +277,10 @@ public class SecorConfig {
         return getBoolean("secor.upload.on.shutdown");
     }
 
+    public boolean getUploadLastSeenOffset() {
+        return getBoolean("secor.upload.last.seen.offset", false);
+    }
+
     public boolean getDeterministicUpload() {
         return getBoolean("secor.upload.deterministic");
     }

--- a/src/main/java/com/pinterest/secor/main/ZookeeperClientMain.java
+++ b/src/main/java/com/pinterest/secor/main/ZookeeperClientMain.java
@@ -87,8 +87,10 @@ public class ZookeeperClientMain {
                     ((Number) commandLine.getParsedOptionValue("partition")).intValue();
                 TopicPartition topicPartition = new TopicPartition(topic, partition);
                 zookeeperConnector.deleteCommittedOffsetPartitionCount(topicPartition);
+                zookeeperConnector.deleteLastSeenOffsetPartitionCount(topicPartition);
             } else {
                 zookeeperConnector.deleteCommittedOffsetTopicCount(topic);
+                zookeeperConnector.deleteLastSeenOffsetTopicCount(topic);
             }
         } catch (Throwable t) {
             LOG.error("Zookeeper client failed", t);

--- a/src/test/java/com/pinterest/secor/common/ZookeeperConnectorTest.java
+++ b/src/test/java/com/pinterest/secor/common/ZookeeperConnectorTest.java
@@ -45,4 +45,21 @@ public class ZookeeperConnectorTest {
         zookeeperConnector.setConfig(secorConfig);
         Assert.assertEquals(expectedOffsetPath, zookeeperConnector.getCommittedOffsetGroupPath());
     }
+
+    @Test
+    public void testGetLastSeenOffsetGroupPath() throws Exception {
+        verifyLastSeen("/", "/consumers/secor_cg/lastSeen");
+        verifyLastSeen("/chroot", "/chroot/consumers/secor_cg/lastSeen");
+        verifyLastSeen("/chroot/", "/chroot/consumers/secor_cg/lastSeen");
+    }
+
+    protected void verifyLastSeen(String zookeeperPath, String expectedOffsetPath) {
+        ZookeeperConnector zookeeperConnector = new ZookeeperConnector();
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.setProperty("kafka.zookeeper.path", zookeeperPath);
+        properties.setProperty("secor.kafka.group", "secor_cg");
+        SecorConfig secorConfig = new SecorConfig(properties);
+        zookeeperConnector.setConfig(secorConfig);
+        Assert.assertEquals(expectedOffsetPath, zookeeperConnector.getLastSeenOffsetGroupPath());
+    }
 }


### PR DESCRIPTION
…stic upload problem mentioned in https://github.com/pinterest/secor/issues/600

When there was a failed attempt uploading for this topic partition, we might end up on S3 with:
                    //     s3n://topic/partition/day/hour=0/offset1
                    //     s3n://topic/partition/day/hour=1/offset1
If this attempty eventually failed and we resume the processing on another node, we might end up with the following upload if the upload was triggered too early because time based upload policy:
                    // might have less files to upload, e.g.
                    //     localfs://topic/partition/day/hour=0/offset1
                    // If we continue uploading, we will upload this file:
                    //     s3n://topic/partition/day/hour=0/offset1
                    // But the next file to be uploaded will become:
                    //     s3n://topic/partition/day/hour=1/offset2
                    // So we will end up with 2 different files for hour=1/

We should wait a bit longer to have at least getting to the same offset as ZK's

Added config property secor.upload.last.seen.offset to support the following upload sequence:

1. acquire ZK lock for the current topic/partition
--- new ---> 1.1 check whether the in-memory lastSeenOffset >= ZK's lastSeenOffset, if not skip the rest;
--- new ---> 1.2 persist the in-memory lastSeenOffset onto ZK lastSeenOffsetPath
2. upload a list of files for the current topic/partition
3. persist the current offset to ZK committedOffset path
4. release ZK lock