### PR TITLE
Reduce the s3cor upload waiting time from 40 seconds to 30 seconds to…

### DIFF
--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -61,7 +61,7 @@ S3_FILESYSTEMS=${S3_FILESYSTEMS:-s3n}
 
 # The minimum wait time is 10 seconds plus delta.  Secor is configured to upload files older than
 # 10 seconds and we need to make sure that everything ends up on s3 before starting verification.
-WAIT_TIME=${SECOR_WAIT_TIME:-40}
+WAIT_TIME=${SECOR_WAIT_TIME:-30}
 BASE_DIR=$(dirname $0)
 CONF_DIR=${BASE_DIR}/..
 


### PR DESCRIPTION
… speed up the integration test.

Currently Travis cuts off on 50 minutes and we issued 22 times: "Waiting 40 sec for Secor to upload logs to s3", this 10 seconds saving should reduce the elapsed time by 3 minutes