### PR TITLE
Add max.poll.interval.ms kafka producer setting

### DIFF
--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -186,6 +186,7 @@ kafka.new.consumer.ssl.keystore.password=
 kafka.new.consumer.ssl.truststore.location=
 kafka.new.consumer.ssl.truststore.password=
 kafka.new.consumer.isolation.level=
+kafka.new.consumer.max.poll.interval.ms=
 kafka.new.consumer.max.poll.records=
 kafka.new.consumer.sasl.client.callback.handler.class=
 kafka.new.consumer.sasl.jaas.config=

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -145,6 +145,10 @@ public class SecorConfig {
         return getString("kafka.new.consumer.isolation.level");
     }
 
+    public String getMaxPollIntervalMs() {
+        return getString("kafka.new.consumer.max.poll.interval.ms");
+    }
+
     public String getMaxPollRecords() {
         return getString("kafka.new.consumer.max.poll.records");
     }

--- a/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
@@ -103,6 +103,7 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator, Rebalanc
         optionalConfig(config.getSslTruststoreLocation(), conf -> props.put("ssl.truststore.location", conf));
         optionalConfig(config.getSslTruststorePassword(), conf -> props.put("ssl.truststore.password", conf));
         optionalConfig(config.getIsolationLevel(), conf -> props.put("isolation.level", conf));
+        optionalConfig(config.getMaxPollIntervalMs(), conf -> props.put("max.poll.interval.ms", conf));
         optionalConfig(config.getMaxPollRecords(), conf -> props.put("max.poll.records", conf));
         optionalConfig(config.getSaslClientCallbackHandlerClass(), conf -> props.put("sasl.client.callback.handler.class", conf));
         optionalConfig(config.getSaslJaasConfig(), conf -> props.put("sasl.jaas.config", conf));


### PR DESCRIPTION
This PR has for goal to enable the configuration of max.poll.interval.ms. As stated in the documentation (https://kafka.apache.org/documentation/#max.poll.interval.ms). This setting can prevent rebalancing during any long upload in Secor.  