### PR TITLE
Add secor.max.active.files property to controll active file count

### DIFF
--- a/src/main/java/com/pinterest/secor/common/FileRegistry.java
+++ b/src/main/java/com/pinterest/secor/common/FileRegistry.java
@@ -258,13 +258,12 @@ public class FileRegistry {
      * @param topicPartition The topic partition to get the age of.
      * @return Age of the most recently created file in the topic partition or -1 if the partition
      *     does not contain any files.
-     * @throws IOException on error
      */
-    public long getModificationAgeSec(TopicPartition topicPartition) throws IOException {
+    public long getModificationAgeSec(TopicPartition topicPartition) {
         return getModificationAgeSec(new TopicPartitionGroup(topicPartition));
     }
 
-    public long getModificationAgeSec(TopicPartitionGroup topicPartitionGroup) throws IOException {
+    public long getModificationAgeSec(TopicPartitionGroup topicPartitionGroup) {
         long now = System.currentTimeMillis() / 1000L;
         long result;
         if (mConfig.getFileAgeYoungest()) {
@@ -296,5 +295,9 @@ public class FileRegistry {
         StatsUtil.setLabel("secor.modification_age_sec." + topicPartitionGroup.getTopic() + "." +
             Arrays.toString(topicPartitionGroup.getPartitions()), Long.toString(result));
         return result;
+    }
+
+    public int getActiveFileCount() {
+        return mWriters.size();
     }
 }

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -277,6 +277,10 @@ public class SecorConfig {
         return getLong("secor.max.file.age.seconds");
     }
 
+    public int getMaxActiveFiles() {
+        return getInt("secor.max.file.count", -1);
+    }
+
     public boolean getUploadOnShutdown() {
         return getBoolean("secor.upload.on.shutdown");
     }
@@ -612,10 +616,6 @@ public class SecorConfig {
       return writerDelimiter;
     }
 
-    public String getPerfTestTopicPrefix() {
-    	return getString("secor.kafka.perf_topic_prefix");
-    }
-
     public String getZookeeperPath() {
         return getString("secor.zookeeper.path");
     }
@@ -776,15 +776,15 @@ public class SecorConfig {
     /**
      * This method is used for fetching all the properties which start with the given prefix.
      * It returns a Map of all those key-val.
-     * 
+     *
      * e.g.
      * a.b.c=val1
      * a.b.d=val2
      * a.b.e=val3
-     * 
+     *
      * If prefix is a.b then,
      * These will be fetched as a map {c = val1, d = val2, e = val3}
-     * 
+     *
      * @param prefix property prefix
      * @return
      */
@@ -806,7 +806,7 @@ public class SecorConfig {
     public Map<String, String> getAvroMessageSchema() {
         return getPropertyMapForPrefix("secor.avro.message.schema");
     }
-    
+
     public String getORCSchemaProviderClass(){
         return getString("secor.orc.schema.provider");
     }

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -299,8 +299,10 @@ public class Uploader {
         } else {
             final long size = mFileRegistry.getSize(topicPartition);
             final long modificationAgeSec = mFileRegistry.getModificationAgeSec(topicPartition);
+            final int fileCount = mFileRegistry.getActiveFileCount();
             LOG.debug("size: " + size + " modificationAge: " + modificationAgeSec);
             shouldUpload = forceUpload ||
+                           activeFileCountExceeded(fileCount) ||
                            size >= mConfig.getMaxFileSizeBytes() ||
                            modificationAgeSec >= mConfig.getMaxFileAgeSeconds() ||
                            isRequiredToUploadAtTime(topicPartition);
@@ -337,6 +339,10 @@ public class Uploader {
                 checkTopicPartition(topicPartition, forceUpload);
             }
         }
+    }
+
+    private boolean activeFileCountExceeded(int fileCount) {
+        return mConfig.getMaxActiveFiles() > -1 && fileCount > mConfig.getMaxActiveFiles();
     }
 
     /**


### PR DESCRIPTION
Partially addresses https://github.com/pinterest/secor/issues/785

Keeps active file under `secor.max.file.count` (default 100)

@HenryCaiHaiying , what do you think, is this the right way to approach this problem? I was thinking, maybe Files should be sorted by size before calling `checkTopicPartition` so that the biggest file is uploaded first, but decided to keep that simple for now.

Tried it for our use case (big number of partitions in small amount of time) it helped with OutOfMemory exception.