### PR TITLE
Add native support for Prometheus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -380,6 +380,11 @@
             <artifactId>micrometer-registry-statsd</artifactId>
             <version>1.5.2</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.5.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/config/secor.common.properties
+++ b/src/main/config/secor.common.properties
@@ -500,6 +500,7 @@ secor.monitoring.metrics.collector.class=com.pinterest.secor.monitoring.OstrichM
 # secor.monitoring.metrics.collector.class=com.pinterest.secor.monitoring.MicroMeterMetricCollector
 # secor.monitoring.metrics.collector.micrometer.jmx.enabled=true
 # secor.monitoring.metrics.collector.micrometer.statsd.enabled=true
+# secor.monitoring.metrics.collector.micrometer.prometheus.enabled=true
 
 # Row group size in bytes for Parquet writers. Specifies how much data will be buffered in memory before flushing a
 # block to disk. Larger values allow for larger column chinks which makes it possible to do larger sequential IO.

--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -766,11 +766,19 @@ public class SecorConfig {
     }
 
     public boolean getMicroMeterCollectorJmxEnabled() {
-        return getBoolean("secor.monitoring.metrics.collector.micrometer.jmx.enabled");
+        return getBoolean("secor.monitoring.metrics.collector.micrometer.jmx.enabled", false);
     }
 
     public boolean getMicroMeterCollectorStatsdEnabled() {
-        return getBoolean("secor.monitoring.metrics.collector.micrometer.statsd.enabled");
+        return getBoolean("secor.monitoring.metrics.collector.micrometer.statsd.enabled", false);
+    }
+
+    public boolean getMicroMeterCollectorPrometheusEnabled() {
+        return getBoolean("secor.monitoring.metrics.collector.micrometer.prometheus.enabled", false);
+    }
+
+    public int getMicroMeterCacheSize() {
+        return getInt("secor.monitoring.metrics.collector.micrometer.cache.size", 500);
     }
 
     /**

--- a/src/main/java/com/pinterest/secor/common/monitoring/PrometheusHandler.java
+++ b/src/main/java/com/pinterest/secor/common/monitoring/PrometheusHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.pinterest.secor.common.monitoring;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.twitter.ostrich.admin.CustomHttpHandler;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+/**
+ * Initializes Http Endpoint for Prometheus
+ *
+ * @author Paulius Dambrauskas (p.dambrauskas@gmail.com)
+ */
+public class PrometheusHandler extends CustomHttpHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(PrometheusHandler.class);
+
+    @Override
+    public void handle(HttpExchange exchange) {
+        Optional<PrometheusMeterRegistry> registry = Metrics.globalRegistry.getRegistries().stream()
+                .filter(meterRegistry -> meterRegistry instanceof PrometheusMeterRegistry)
+                .map(meterRegistry -> (PrometheusMeterRegistry) meterRegistry)
+                .findFirst();
+        if (registry.isPresent()) {
+            this.render(registry.get().scrape(), exchange, HttpStatus.SC_OK);
+        } else {
+            LOG.warn("Trying to scrape prometheus, while it is disabled, " +
+                    "set \"secor.monitoring.metrics.collector.micrometer.prometheus.enabled\" to \"true\"");
+            this.render("Not Found", exchange, HttpStatus.SC_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/pinterest/secor/consumer/Consumer.java
+++ b/src/main/java/com/pinterest/secor/consumer/Consumer.java
@@ -73,8 +73,9 @@ public class Consumer extends Thread {
     private volatile boolean mShuttingDown = false;
     private static volatile boolean mCallingSystemExit = false;
 
-    public Consumer(SecorConfig config) {
+    public Consumer(SecorConfig config, MetricCollector metricCollector) {
         mConfig = config;
+        mMetricCollector = metricCollector;
         isLegacyConsumer = true;
     }
 
@@ -89,8 +90,6 @@ public class Consumer extends Thread {
         }
         mKafkaMessageIterator = KafkaMessageIteratorFactory.getIterator(mConfig.getKafkaMessageIteratorClass(), mConfig);
         mMessageReader = new MessageReader(mConfig, mOffsetTracker, mKafkaMessageIterator);
-        mMetricCollector = ReflectionUtil.createMetricCollector(mConfig.getMetricsCollectorClass());
-        mMetricCollector.initialize(mConfig);
 
         FileRegistry fileRegistry = new FileRegistry(mConfig);
         UploadManager uploadManager = ReflectionUtil.createUploadManager(mConfig.getUploadManagerClass(), mConfig);

--- a/src/test/java/com/pinterest/secor/monitoring/PrometheusTest.java
+++ b/src/test/java/com/pinterest/secor/monitoring/PrometheusTest.java
@@ -1,0 +1,41 @@
+package com.pinterest.secor.monitoring;
+
+import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.monitoring.PrometheusHandler;
+import com.sun.net.httpserver.HttpExchange;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class PrometheusTest {
+
+    @Test
+    public void testPrometheusIntegration() throws IOException {
+        PropertiesConfiguration properties = new PropertiesConfiguration();
+        properties.addProperty("secor.monitoring.metrics.collector.micrometer.prometheus.enabled", true);
+        SecorConfig config = new SecorConfig(properties);
+        MetricCollector collector = new MicroMeterMetricCollector();
+        collector.initialize(config);
+
+        final List<String> responses = new ArrayList<>();
+        PrometheusHandler handler = new PrometheusHandler() {
+            @Override
+            public void render(String body, HttpExchange exchange, int code) {
+                responses.add(body);
+            }
+        };
+        HttpExchange exchange = mock(HttpExchange.class);
+
+        collector.gauge("test", 1, "topic");
+
+        handler.handle(exchange);
+        assertTrue(responses.get(0).contains("test{topic=\"topic\",} 1.0"));
+    }
+
+}

--- a/src/test/java/com/pinterest/secor/performance/PerformanceTest010.java
+++ b/src/test/java/com/pinterest/secor/performance/PerformanceTest010.java
@@ -35,7 +35,7 @@
 //import com.google.common.collect.Maps;
 //import com.pinterest.secor.common.LegacyKafkaClient;
 //import com.pinterest.secor.common.OffsetTracker;
-//import com.pinterest.secor.common.OstrichAdminService;
+//import com.pinterest.secor.common.monitoring.OstrichAdminService;
 //import com.pinterest.secor.common.SecorConfig;
 //import com.pinterest.secor.common.TopicPartition;
 //import com.pinterest.secor.consumer.Consumer;

--- a/src/test/java/com/pinterest/secor/performance/PerformanceTest08.java
+++ b/src/test/java/com/pinterest/secor/performance/PerformanceTest08.java
@@ -33,7 +33,7 @@
 //import com.google.common.collect.Maps;
 //import com.pinterest.secor.common.LegacyKafkaClient;
 //import com.pinterest.secor.common.OffsetTracker;
-//import com.pinterest.secor.common.OstrichAdminService;
+//import com.pinterest.secor.common.monitoring.OstrichAdminService;
 //import com.pinterest.secor.common.SecorConfig;
 //import com.pinterest.secor.common.TopicPartition;
 //import com.pinterest.secor.consumer.Consumer;


### PR DESCRIPTION
We are running Secor on K8s and monitoring our stack with Prometheus.
As Secor uses Micrometer, it is not that hard to add Prometheus support directly, and avoid using exporters for Secor metrics.

I've changed the way `gauge` method works, because Prometheus endpoint was returning `NaN` values.
More on that https://stackoverflow.com/questions/50821924/micrometer-prometheus-gauge-displays-nan

I've added `/prometheus` endpoint to Ostrich Server to avoid making things complicated with listening to some other port.

Also moved initialization of metric controller up to `ConsumerMain` class. I guess we don't need to have different instances for each Consumer. Otherwise  I'd have to ensure, that there is only one instance of PrometheusMetricRegistry to avoid duplications  and other problems on Prometheus http endpoint. This shouldnt be a problem, as Metric registries are delegating calls to static methods anyway.

ref: https://github.com/pinterest/secor/issues/430