### PR TITLE
Javadoc Update: fix a few missing params and exclude a few packages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -686,7 +686,8 @@
                               </execution>
                           </executions>
                         <configuration>
-                            <excludePackageNames>com.pinterest.secor.*</excludePackageNames>
+                            <source>8</source>
+                            <excludePackageNames>com.pinterest.secor.timestamp:com.pinterest.secor.reader:com.pinterest.secor.common:com.pinterest.secor.thrift</excludePackageNames>
                         </configuration>
                     </plugin>
                     <plugin>

--- a/src/main/java/com/pinterest/secor/monitoring/MetricCollector.java
+++ b/src/main/java/com/pinterest/secor/monitoring/MetricCollector.java
@@ -28,7 +28,7 @@ import com.pinterest.secor.common.SecorConfig;
 public interface MetricCollector {
     /**
      * Initialize the collector with SecorConfig
-     * @param config
+     * @param config configuration
      */
     void initialize(SecorConfig config);
 

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -75,7 +75,9 @@ public class Uploader {
      * @param offsetTracker Tracker of the current offset of topics partitions
      * @param fileRegistry Registry of log files on a per-topic and per-partition basis
      * @param uploadManager Manager of the physical upload of log files to the remote repository
+     * @param messageReader messageReader
      * @param metricCollector component that ingest metrics into monitoring system
+     * @param deterministicUploadPolicyTracker deterministicUploadPolicyTracker
      */
     public void init(SecorConfig config, OffsetTracker offsetTracker, FileRegistry fileRegistry,
                      UploadManager uploadManager, MessageReader messageReader, MetricCollector metricCollector,
@@ -354,6 +356,7 @@ public class Uploader {
      * This method could be subclassed to provide an alternate policy. The custom uploader
      * class name would need to be specified in the secor.upload.class.
      *
+     * @param forceUpload forceUpload
      * @throws Exception if any error occurs while appying the policy
      */
     public void applyPolicy(boolean forceUpload) throws Exception {


### PR DESCRIPTION
Add source jdk8 compatibility flag

Makes maven javadoc:javadoc succeed again