### PR TITLE
Fix file extension after trim

### DIFF
--- a/src/main/java/com/pinterest/secor/common/LogFilePath.java
+++ b/src/main/java/com/pinterest/secor/common/LogFilePath.java
@@ -119,15 +119,15 @@ public class LogFilePath {
         // Parse basename.
         String basename = pathElements[pathElements.length - 1];
         // Remove extension.
-        int lastIndexOf = basename.lastIndexOf('.');
-        if (lastIndexOf >= 0) {
-            mExtension = basename.substring(lastIndexOf, basename.length());
-            basename = basename.substring(0, lastIndexOf);
+        int indexOfSeparator = basename.indexOf('.');
+        if (indexOfSeparator >= 0) {
+            mExtension = basename.substring(indexOfSeparator);
+            basename = basename.substring(0, indexOfSeparator);
         } else {
             mExtension = "";
         }
         String[] basenameElements = basename.split("_");
-        assert basenameElements.length == 3: Integer.toString(basenameElements.length) + " == 3";
+        assert basenameElements.length == 3: basenameElements.length + " == 3";
         mGeneration = Integer.parseInt(basenameElements[0]);
         mKafkaPartitions = new int[]{Integer.parseInt(basenameElements[1])};
         mOffsets = new long[]{Long.parseLong(basenameElements[2])};

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -220,10 +220,8 @@ public class Uploader {
         mFileRegistry.deleteWriter(srcPath);
         try {
             CompressionCodec codec = null;
-            String extension = "";
             if (mConfig.getCompressionCodec() != null && !mConfig.getCompressionCodec().isEmpty()) {
                 codec = CompressionUtil.createCompressionCodec(mConfig.getCompressionCodec());
-                extension = codec.getDefaultExtension();
             }
             reader = createReader(srcPath, codec);
             KeyValue keyVal;
@@ -235,7 +233,7 @@ public class Uploader {
                         dstPath = new LogFilePath(localPrefix, srcPath.getTopic(),
                                                   srcPath.getPartitions(), srcPath.getGeneration(),
                                                   srcPath.getKafkaPartition(), startOffset,
-                                                  extension);
+                                                  srcPath.getExtension());
                         writer = mFileRegistry.getOrCreateWriter(dstPath,
                         		codec);
                     }

--- a/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
+++ b/src/test/java/com/pinterest/secor/uploader/UploaderTest.java
@@ -81,6 +81,7 @@ public class UploaderTest extends TestCase {
     private TopicPartition mTopicPartition;
 
     private LogFilePath mLogFilePath;
+    private LogFilePath mLogFilePathWithExtension;
 
     private SecorConfig mConfig;
     private OffsetTracker mOffsetTracker;
@@ -99,6 +100,9 @@ public class UploaderTest extends TestCase {
         mLogFilePath = new LogFilePath("/some_parent_dir",
                 "/some_parent_dir/some_topic/some_partition/some_other_partition/"
                         + "10_0_00000000000000000010");
+        mLogFilePathWithExtension = new LogFilePath("/some_parent_dir",
+                "/some_parent_dir/some_topic/some_partition/some_other_partition/"
+                        + "10_0_00000000000000000010.snappy.parquet");
 
         mConfig = Mockito.mock(SecorConfig.class);
         Mockito.when(mConfig.getLocalPath()).thenReturn("/some_parent_dir");
@@ -282,7 +286,7 @@ public class UploaderTest extends TestCase {
                 .thenReturn(21L);
 
         HashSet<LogFilePath> logFilePaths = new HashSet<LogFilePath>();
-        logFilePaths.add(mLogFilePath);
+        logFilePaths.add(mLogFilePathWithExtension);
         Mockito.when(mFileRegistry.getPaths(mTopicPartition)).thenReturn(
                 logFilePaths);
 
@@ -308,7 +312,7 @@ public class UploaderTest extends TestCase {
         LogFilePath dstLogFilePath = new LogFilePath(
                 "/some_parent_dir/some_message_dir",
                 "/some_parent_dir/some_message_dir/some_topic/some_partition/"
-                        + "some_other_partition/10_0_00000000000000000021");
+                        + "some_other_partition/10_0_00000000000000000021.snappy.parquet");
         Mockito.when(mFileRegistry.getOrCreateWriter(dstLogFilePath, null))
                 .thenReturn(writer);
 


### PR DESCRIPTION
After trimming files, dest files were losing their extensions and using codec extension instead.
So `secor.file.extension` was ignored, after trimming files.

Also LogFilePath constructor used in tests & verifier was not working with double extentions, for exapmle `.snappy.parquet`.
