### PR TITLE
Adding canned ACL to uploadRequest.

### DIFF
--- a/src/main/java/com/pinterest/secor/uploader/S3UploadManager.java
+++ b/src/main/java/com/pinterest/secor/uploader/S3UploadManager.java
@@ -162,7 +162,7 @@ public class S3UploadManager extends UploadManager {
         }
 
         // make upload request, taking into account configured options for encryption
-        PutObjectRequest uploadRequest = new PutObjectRequest(s3Bucket, s3Key, localFile);
+        PutObjectRequest uploadRequest = new PutObjectRequest(s3Bucket, s3Key, localFile).withCannedAcl(CannedAccessControlList.BucketOwnerFullControl);
         if (!mConfig.getAwsSseType().isEmpty()) {
             if (S3.equals(mConfig.getAwsSseType())) {
                 LOG.info("uploading file {} to s3://{}/{} with S3-managed encryption", localFile, s3Bucket, s3Key);


### PR DESCRIPTION
Our Secor deployments are in Ops account and it is writing to a bucket in the DataScience account.

Because it is cross account, we need to set the the ACL on each object so that the bucket owner has access to the files.
