### PR TITLE
Fix building project due to insecure repo URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,32 +68,32 @@
     <repositories>
         <repository>
             <id>Twitter public Maven repo</id>
-            <url>http://maven.twttr.com</url>
+            <url>https://maven.twttr.com</url>
         </repository>
         <repository>
             <id>Typesafe public Maven repo</id>
-            <url>http://repo.typesafe.com/typesafe/releases</url>
+            <url>https://repo.typesafe.com/typesafe/releases</url>
         </repository>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
         <repository>
             <id>central</id>
             <name>Maven Repository Switchboard</name>
             <layout>default</layout>
-            <url>http://repo1.maven.org/maven2/</url>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>Twitter public Maven repo</id>
-            <url>http://maven.twttr.com</url>
+            <url>https://maven.twttr.com</url>
         </pluginRepository>
         <pluginRepository>
             <id>Typesafe public Maven repo</id>
-            <url>http://repo.typesafe.com/typesafe/releases</url>
+            <url>https://repo.typesafe.com/typesafe/releases</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
Maven repos now require connections over HTTPS only and won't accept HTTP