### PR TITLE
Do not fail on write error

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorConfig.java
+++ b/src/main/java/com/pinterest/secor/common/SecorConfig.java
@@ -269,6 +269,10 @@ public class SecorConfig {
         return getInt("secor.consumer.threads");
     }
 
+    public int getMaxBadMessages() {
+        return getInt("secor.consumer.max_bad_messages", 1000);
+    }
+
     public long getMaxFileSizeBytes() {
         return getLong("secor.max.file.size.bytes");
     }


### PR DESCRIPTION

Fixes #1505 

This issue occurred to us too. Found existing issue about it and made this PR.

- Moved offset parsing and message parsing to single `try/catch` block
- Reused fail backoff logic which was implemented in parse block
- Made fail threshold configurable
- Split `consumeNextMessage` to multiple smaller methods to make it more readable.
