### PR TITLE
changed the partition order: timestamp then field

### DIFF
--- a/src/main/java/com/pinterest/secor/parser/AvroSplitByFieldMessageParser.java
+++ b/src/main/java/com/pinterest/secor/parser/AvroSplitByFieldMessageParser.java
@@ -77,7 +77,7 @@ public class AvroSplitByFieldMessageParser extends TimestampedMessageParser impl
         long timestampMillis = extractTimestampMillis(record);
 
         String[] timestampPartitions = generatePartitions(timestampMillis, mUsingHourly, mUsingMinutely);
-        return (String[]) ArrayUtils.addAll(new String[]{mFieldPrefix + eventType}, timestampPartitions);
+        return (String[]) ArrayUtils.addAll(timestampPartitions, new String[]{mFieldPrefix + eventType});
     }
 
     @Override


### PR DESCRIPTION
The secor has a nice feature that can split messages by field name. We want to split messages by groupId so that we can delete a specific customer data easily. By default, the order of partition is `field/timestamp`. We want to have the order of `timestamp/field`.