### PR TITLE
Remove writing to Zookeeper when kafka is selected as offset storage and dual.commit is false.

### DIFF
--- a/src/main/java/com/pinterest/secor/reader/KafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/KafkaMessageIterator.java
@@ -29,4 +29,6 @@ public interface KafkaMessageIterator {
     Message next();
     void init(SecorConfig config) throws UnknownHostException;
     void commit(TopicPartition topicPartition, long offset);
+
+    long getKafkaCommitedOffsetCount(TopicPartition topicPartition);
 }

--- a/src/main/java/com/pinterest/secor/reader/LegacyKafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/LegacyKafkaMessageIterator.java
@@ -20,6 +20,7 @@ package com.pinterest.secor.reader;
 
 import com.google.common.collect.ImmutableMap;
 import com.pinterest.secor.common.SecorConfig;
+import com.pinterest.secor.common.SecorConstants;
 import com.pinterest.secor.common.TopicPartition;
 import com.pinterest.secor.message.Message;
 import com.pinterest.secor.timestamp.KafkaMessageTimestampFactory;
@@ -124,6 +125,10 @@ public class LegacyKafkaMessageIterator implements KafkaMessageIterator {
         // Properties required to upgrade from kafka 0.8.x to 0.9.x
         props.put("dual.commit.enabled", mConfig.getDualCommitEnabled());
         props.put("offsets.storage", mConfig.getOffsetsStorage());
+
+        if (mConfig.getDualCommitEnabled().equals("false") && mConfig.getOffsetsStorage() == SecorConstants.KAFKA_OFFSETS_STORAGE_KAFKA) {
+            throw new RuntimeException("Legacy Kafka consumer does not support storing offsets only in Kafka!");
+        }
 
         props.put("partition.assignment.strategy", mConfig.getPartitionAssignmentStrategy());
         if (mConfig.getRebalanceMaxRetries() != null &&

--- a/src/main/java/com/pinterest/secor/reader/MessageReader.java
+++ b/src/main/java/com/pinterest/secor/reader/MessageReader.java
@@ -119,4 +119,8 @@ public class MessageReader {
     public void commit(TopicPartition topicPartition, long offset) {
         mKafkaMessageIterator.commit(topicPartition, offset);
     }
+
+    public long getCommitedOffsetCount(TopicPartition topicPartition) {
+        return mKafkaMessageIterator.getKafkaCommitedOffsetCount(topicPartition);
+    }
 }

--- a/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
@@ -159,4 +159,12 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator, Rebalanc
         String offsetStorage = config.getOffsetsStorage();
         return offsetStorage.equals("kafka") && dualCommitEnabled.equals("false");
     }
+
+    @Override
+    public long getKafkaCommitedOffsetCount(final com.pinterest.secor.common.TopicPartition topicPartition) {
+        TopicPartition kafkaTopicPartition = new TopicPartition(topicPartition.getTopic(), topicPartition.getPartition());
+        OffsetAndMetadata offsetAndMetadata = mKafkaConsumer.committed(kafkaTopicPartition);
+
+        return offsetAndMetadata.offset();
+    }
 }

--- a/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
@@ -154,12 +154,9 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator, Rebalanc
         }
     }
 
-
     private boolean getSkipZookeeperOffsetSeek(SecorConfig config) {
-
         String dualCommitEnabled = config.getDualCommitEnabled();
         String offsetStorage = config.getOffsetsStorage();
-        return offsetStorage.equals("kafka") && dualCommitEnabled.equals("true");
-
+        return offsetStorage.equals("kafka") && dualCommitEnabled.equals("false");
     }
 }

--- a/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
+++ b/src/main/java/com/pinterest/secor/reader/SecorKafkaMessageIterator.java
@@ -144,7 +144,6 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator, Rebalanc
     @Override
     public void subscribe(RebalanceHandler handler, SecorConfig config) {
         ConsumerRebalanceListener reBalanceListener = new SecorConsumerRebalanceListener(mKafkaConsumer, mZookeeperConnector, getSkipZookeeperOffsetSeek(config), config.getNewConsumerAutoOffsetReset(), handler);
-        ;
 
         String[] subscribeList = config.getKafkaTopicList();
         if (subscribeList.length == 0 || Strings.isNullOrEmpty(subscribeList[0])) {
@@ -164,7 +163,10 @@ public class SecorKafkaMessageIterator implements KafkaMessageIterator, Rebalanc
     public long getKafkaCommitedOffsetCount(final com.pinterest.secor.common.TopicPartition topicPartition) {
         TopicPartition kafkaTopicPartition = new TopicPartition(topicPartition.getTopic(), topicPartition.getPartition());
         OffsetAndMetadata offsetAndMetadata = mKafkaConsumer.committed(kafkaTopicPartition);
-
-        return offsetAndMetadata.offset();
+        if (offsetAndMetadata != null) {
+            return offsetAndMetadata.offset();
+        } else {
+            return -1;
+        }
     }
 }

--- a/src/main/scripts/run_tests.sh
+++ b/src/main/scripts/run_tests.sh
@@ -502,9 +502,12 @@ for fkey in ${S3_FILESYSTEMS}; do
         echo "Running tests for Message Type: ${MESSAGE_TYPE} and  ReaderWriter:${READER_WRITERS[${key}]} using filesystem: ${FILESYSTEM_TYPE}"
         if [ ${MESSAGE_TYPE} = "binary" ]; then
             post_stop_and_verity_test "kafka" "true"
-            post_stop_and_verity_test "kafka" "false"
             post_stop_and_verity_test "zookeeper" "true"
             post_stop_and_verity_test "zookeeper" "false"
+            if [[ "$MVN_PROFILE" == kafka-2.0.0 ]];then
+              post_stop_and_verity_test "kafka" "false"
+            fi
+
         else
             post_stop_and_verity_test "zookeeper" "false"
         fi


### PR DESCRIPTION
This PR changes the way secor uses Zookeeper for storing offsets. Currently, secor will use zookeeper to store offsets no matter what settings are selected. This PR makes secor only use zookeeper for storing offsets in two cases:
 1. LegacyKafkaConsumer is used ( it will always use zookeeper for that).
 2. New KafkaConsumer is used and offset storage is set to `zookeeper` or `dual.commit` is enabled.
 