### PR TITLE
Add guard for consumer.seek when using endoffsets

### DIFF
--- a/src/main/java/com/pinterest/secor/common/SecorKafkaClient.java
+++ b/src/main/java/com/pinterest/secor/common/SecorKafkaClient.java
@@ -66,6 +66,10 @@ public class SecorKafkaClient implements KafkaClient {
         org.apache.kafka.common.TopicPartition kafkaTopicPartition = new org.apache.kafka.common.TopicPartition(topicPartition.getTopic(), topicPartition.getPartition());
         mKafkaConsumer.assign(Collections.singleton(kafkaTopicPartition));
         long endOffset = mKafkaConsumer.endOffsets(Collections.singleton(kafkaTopicPartition)).get(kafkaTopicPartition);
+        // https://github.com/pinterest/secor/issues/2155#issue-1054846748
+        if (endOffset == 0) {
+            return null;
+        }
         mKafkaConsumer.seek(kafkaTopicPartition, endOffset - 1);
 
         return readSingleMessage(mKafkaConsumer);


### PR DESCRIPTION
address #2155 
When there is no message written in the topic partition, the endOffsets method return 0 as default.
https://kafka.apache.org/22/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#endOffsets-java.util.Collection-
This causes seek value to be -1 which fails the PartitionFinalizer since the offset is negative.
https://kafka.apache.org/22/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#seek-org.apache.kafka.common.TopicPartition-long-