### PR TITLE
Fixed test order depedency invoked by a previous PR

### DIFF
--- a/src/test/java/com/pinterest/secor/io/FileReaderWriterFactoryTest.java
+++ b/src/test/java/com/pinterest/secor/io/FileReaderWriterFactoryTest.java
@@ -111,6 +111,17 @@ public class FileReaderWriterFactoryTest extends TestCase {
     private void mockDelimitedTextFileWriter(boolean isCompressed) throws Exception {
         Path fsPath = (!isCompressed) ? new Path(PATH) : new Path(PATH_GZ);
 
+        // This code chunk makes a dummy mock that invokes the argument matcher for FileSystem to avoid order dependency
+        PowerMockito.mockStatic(SequenceFile.class);
+        SequenceFile.Writer dummyWriter = Mockito
+                .mock(SequenceFile.Writer.class);
+        Mockito.when(
+                SequenceFile.createWriter(Mockito.any(FileSystem.class),
+                        Mockito.any(Configuration.class),
+                        Mockito.eq(fsPath), Mockito.eq(LongWritable.class),
+                        Mockito.eq(BytesWritable.class)))
+                .thenReturn(dummyWriter);
+
         GzipCodec codec = PowerMockito.mock(GzipCodec.class);
         PowerMockito.whenNew(GzipCodec.class).withNoArguments()
                 .thenReturn(codec);


### PR DESCRIPTION
**Description**
In a previous PR https://github.com/pinterest/secor/pull/1687, the use of `PowerMockito.stub()` resolves occasional test failure as mentioned in https://github.com/pinterest/secor/issues/1686. However, there exists test order dependency after the fix. Specifically, the tests `FileReaderWriterFactoryTest#testDelimitedTextFileReader` and `FileReaderWriterFactoryTest#testDelimitedTextFileWriter` fail when running on their owns. This can be verified by running `mvn test -Dtest=FileReaderWriterFactoryTest#testDelimitedTextFileWriter`. 

**Sample Output**
```
[ERROR] testDelimitedTextFileWriter(com.pinterest.secor.io.FileReaderWriterFactoryTest)  Time elapsed: 5.069 s  <<< ERROR!
java.lang.ExceptionInInitializerError
        at com.pinterest.secor.io.FileReaderWriterFactoryTest.testDelimitedTextFileWriter(FileReaderWriterFactoryTest.java:257)
Caused by: java.lang.IllegalStateException: Failed to transform class with name org.apache.hadoop.fs.FileSystem$Cache. Reason: org.apache.hadoop.fs.FileSystem$Cache$Key class is frozen
```
**Reason**
The `class is frozen` error is eradicated if there is a previous `mockito.mock()` call that invokes the argument matcher (i.e. `any()`) for `FileSystem` class. When mocking the instance methods `open` and `create` in `mockDelimitedTextFileWriter`, the `stub()` routine does not invoke this. Hence the two tests work fine when running after `testSequenceFileWriter()` or `testSequenceFileReader()`, but fails when the order dependency is removed.

**Proposed Fixes**
Add a dummy `mockito.mock()` call to unfreeze the `FileSystem$Cache$Key` class. This increases overhead but ensures independency of unit tests